### PR TITLE
Release after TX commit

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,10 +1,8 @@
 name: CI/CD
 
 on:
-  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
-  pull_request: # Runs whenever a pull request is created or updated
   push: # Runs whenever a commit is pushed to the repository
-    branches: [master, tx-pull-manual]
+  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,6 +2,7 @@ name: CI/CD
 
 on:
   push: # Runs whenever a commit is pushed to the repository
+  workflow_call: # Allows another workflow to call this one
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
 
 concurrency:

--- a/.github/workflows/daily-tx-pull.yml
+++ b/.github/workflows/daily-tx-pull.yml
@@ -47,7 +47,12 @@ jobs:
           git add .
           if git diff --cached --exit-code --quiet; then
             echo "Nothing to commit."
+            echo "::set-env name=MADE_CHANGES::false"
           else
             git commit -m "pull new editor translations from Transifex"
             git push origin HEAD:master
+            echo "::set-env name=MADE_CHANGES::true"
           fi
+      - name: Start CI/CD workflow if changes were made
+        if: env.MADE_CHANGES == 'true'
+        uses: ./.github/workflows/ci-cd.yml


### PR DESCRIPTION
### Proposed Changes

Run the CI/CD workflow after the daily TX update, but only if changes were made.

### Reason for Changes

Under CCI, if the daily TX update pushed a commit, that push would trigger a regular build and release. Under GHA, one workflow's actions are normally prevented from triggering another workflow (see [here](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)). This means that, after GHA migration, the daily TX update would make a commit but that commit was not being released. This change fixes that, so the `scratch-l10n` module on NPM will once again automatically stay up to date with changes made on TX.

### Testing

Since this relies on interaction between the workflows and there are not currently any changes ready on TX, I have not fully tested the `workflow_call` yet. I'll have to watch what happens in the next day (or few days) to make sure it works. The good news is that if that step fails, we're no worse off than we are today.