### PR TITLE
More GitHub Actions maintenance

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,8 +22,7 @@ jobs:
       TRIGGER_DEPLOY: ${{ startsWith(github.ref, 'refs/heads/master') }}
     steps:
       - uses: actions/checkout@v4
-      - uses: wagoid/commitlint-github-action@v5
-        if: github.event_name == 'pull_request'
+
       - uses: actions/setup-node@v3
         with:
           cache: "npm"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,13 @@
+name: Lint commit messages
+on: [pull_request]
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/daily-tx-pull.yml
+++ b/.github/workflows/daily-tx-pull.yml
@@ -41,18 +41,19 @@ jobs:
           npm run test
 
       - name: Commit translation updates
+        id: commit
         run: |
           git config --global user.email $(git log --pretty=format:"%ae" -n1)
           git config --global user.name $(git log --pretty=format:"%an" -n1)
           git add .
           if git diff --cached --exit-code --quiet; then
+            echo "MADE_CHANGES=false" >> "$GITHUB_OUTPUT"
             echo "Nothing to commit."
-            echo "::set-env name=MADE_CHANGES::false"
           else
             git commit -m "pull new editor translations from Transifex"
+            echo "MADE_CHANGES=true" >> "$GITHUB_OUTPUT"
             git push origin HEAD:master
-            echo "::set-env name=MADE_CHANGES::true"
           fi
       - name: Start CI/CD workflow if changes were made
-        if: env.MADE_CHANGES == 'true'
+        if: steps.commit.outputs.MADE_CHANGES == 'true'
         uses: ./.github/workflows/ci-cd.yml


### PR DESCRIPTION
### Proposed Changes

- Attempt #185 again, using a step output parameter this time
  - In #185, this used an outdated syntax for setting an environment variable. That syntax is [deprecated and blocked by default](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), so it didn't work.
  - This PR uses a step output parameter instead.
  - This could have been solved by using `echo STUFF >> "$GITHUB_ENV"` but I think using a step output is even better, mainly because it's more clear what kind of changes `MADE_CHANGES` is talking about.
  - I also reordered the commands so that if writing the step output fails, the step will fail before pushing the changes. That means we'll no longer end up with half-released changes (released on GitHub but not NPM).
- Move the commitlint action into its own separate workflow
  - When #185 disabled the `pull_request` trigger for the `ci-cd` workflow, it also effectively disabled commitlint. That's because the step itself checks if the reason it's running is the `pull_request` trigger, which will now never be true. Oops.
  - This brings it back, but only runs it on PRs.