### PR TITLE
Fix workflow call

### DIFF
--- a/.github/workflows/daily-tx-pull.yml
+++ b/.github/workflows/daily-tx-pull.yml
@@ -20,6 +20,9 @@ jobs:
   daily-tx-pull:
     runs-on: ubuntu-latest
 
+    outputs:
+      MADE_CHANGES: ${{ steps.commit.outputs.MADE_CHANGES }}
+
     env:
       # Organization-wide secrets
       TX_TOKEN: ${{ secrets.TX_TOKEN }}
@@ -54,6 +57,7 @@ jobs:
             echo "MADE_CHANGES=true" >> "$GITHUB_OUTPUT"
             git push origin HEAD:master
           fi
-      - name: Start CI/CD workflow if changes were made
-        if: steps.commit.outputs.MADE_CHANGES == 'true'
-        uses: ./.github/workflows/ci-cd.yml
+  call-ci-cd:
+    uses: ./.github/workflows/ci-cd.yml
+    needs: daily-tx-pull
+    if: needs.daily-tx-pull.outputs.MADE_CHANGES == 'true'

--- a/.github/workflows/daily-tx-pull.yml
+++ b/.github/workflows/daily-tx-pull.yml
@@ -55,7 +55,7 @@ jobs:
           else
             git commit -m "pull new editor translations from Transifex"
             echo "MADE_CHANGES=true" >> "$GITHUB_OUTPUT"
-            git push origin HEAD:master
+            git push
           fi
   call-ci-cd:
     uses: ./.github/workflows/ci-cd.yml


### PR DESCRIPTION
### Proposed Changes

Call `ci-cd.yml` workflow from a job instead of a step, since GHA doesn't allow calling a workflow from a step :sweat_smile:

Also, use `git push` instead of `git push origin master` when pushing changes in the `Commit translation updates` step. When running the daily job this won't change behavior, but it does allow testing the `daily-tx-pull` workflow without contaminating the `master` branch.

Speaking of testing, check this out: https://github.com/scratchfoundation/scratch-l10n/actions/runs/6961962062

Note that the `ci-cd.yml` workflow was set up to fail early on that run to save time. The important part is that `ci-cd.yml` ran at all. Woo!
