### PR TITLE
refactor: bound and harden Transifex help-sync error handling

### DIFF
--- a/.github/workflows/daily-help-update.yml
+++ b/.github/workflows/daily-help-update.yml
@@ -19,6 +19,9 @@ permissions:
 jobs:
   daily-help-update:
     runs-on: ubuntu-latest
+    # Backstop only: the sync should finish in a few minutes. The Transifex client code bounds its
+    # own waits, so this guards against an unexpected hang rather than being the primary timeout.
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6

--- a/.github/workflows/daily-help-update.yml
+++ b/.github/workflows/daily-help-update.yml
@@ -45,9 +45,9 @@ jobs:
         if: success()
         run: |
           if [ -s "${{ runner.temp }}/sync-help-warnings.txt" ]; then
-            echo "has_warnings=true" >> $GITHUB_OUTPUT
-            echo "### Sync Help Warnings" >> $GITHUB_STEP_SUMMARY
-            cat "${{ runner.temp }}/sync-help-warnings.txt" >> $GITHUB_STEP_SUMMARY
+            echo "has_warnings=true" >> "$GITHUB_OUTPUT"
+            echo "### Sync Help Warnings" >> "$GITHUB_STEP_SUMMARY"
+            cat "${{ runner.temp }}/sync-help-warnings.txt" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - uses: ./.github/actions/report-scheduled-issue

--- a/scripts/lib/errors.mts
+++ b/scripts/lib/errors.mts
@@ -1,0 +1,12 @@
+/**
+ * @file
+ * Small shared helpers for working with caught values.
+ */
+
+/**
+ * Extract a human-readable message from a caught value. `catch` values are typed `unknown` and are
+ * not guaranteed to be `Error` instances, so read `.message` only when it really is one.
+ * @param err - the caught value
+ * @returns the error message, or a string representation of a non-Error throw
+ */
+export const messageOf = (err: unknown): string => (err instanceof Error ? err.message : String(err))

--- a/scripts/lib/freshdesk-api.mts
+++ b/scripts/lib/freshdesk-api.mts
@@ -12,7 +12,7 @@ export interface HttpError extends Error {
 }
 
 /**
- * Properties to provide when creating a Category throught the Freshdesk API. Also works for updates.
+ * Properties to provide when creating a Category through the Freshdesk API. Also works for updates.
  * @see https://developers.freshdesk.com/api/#create_solution_category
  */
 export interface FreshdeskCategoryCreate {
@@ -38,7 +38,7 @@ export interface FreshdeskCategory extends FreshdeskCategoryCreate {
 }
 
 /**
- * Properties to provide when creating a Folder throught the Freshdesk API. Also works for updates.
+ * Properties to provide when creating a Folder through the Freshdesk API. Also works for updates.
  * @see https://developers.freshdesk.com/api/#create_solution_folder
  */
 export interface FreshdeskFolderCreate {
@@ -89,7 +89,7 @@ export enum FreshdeskFolderVisibility {
 }
 
 /**
- * Properties to provide when creating an Article throught the Freshdesk API. Also works for updates.
+ * Properties to provide when creating an Article through the Freshdesk API. Also works for updates.
  * @see https://developers.freshdesk.com/api/#create_solution_article
  */
 export interface FreshdeskArticleCreate {
@@ -166,11 +166,14 @@ export class FreshdeskApi {
   }
 
   /**
-   * Checks the status of a response. If status is not ok, or the body is not JSON, raise exception
+   * Checks the status of a response. If status is not ok, or the body is not JSON, raise exception.
+   * On error, the response body is included in the message: Freshdesk reports the actual reason for
+   * a failure there (for example `{"code":"access_denied","message":"..."}`), so surfacing it turns
+   * an opaque "HTTP 403" into something diagnosable.
    * @param res - The response object
    * @returns the response if it is ok
    */
-  checkStatus(res: Response) {
+  async checkStatus(res: Response) {
     if (res.ok) {
       if (res.headers.get('content-type')?.includes('application/json')) {
         return res
@@ -180,6 +183,12 @@ export class FreshdeskApi {
     let message = `HTTP ${res.status} ${res.statusText} for ${res.url}`
     if (res.status === 403) {
       message += ` -- this item may have been deleted in Freshdesk, or the API key lacks permission.`
+    }
+    // Read the body for the underlying reason. It is safe to consume here because we only reach this
+    // point on error and are about to throw; the caller never reads the body of a failed response.
+    const body = (await res.text().catch(() => '')).trim()
+    if (body) {
+      message += ` -- response: ${body.length > 500 ? `${body.slice(0, 500)}...` : body}`
     }
     const err = new Error(message) as HttpError
     err.code = res.status
@@ -191,7 +200,7 @@ export class FreshdeskApi {
 
   async listCategories(): Promise<FreshdeskCategory[]> {
     const res = await fetch(`${this.baseUrl}/api/v2/solutions/categories`, { headers: this.defaultHeaders })
-    this.checkStatus(res)
+    await this.checkStatus(res)
     return (await res.json()) as FreshdeskCategory[]
   }
 
@@ -199,7 +208,7 @@ export class FreshdeskApi {
     const res = await fetch(`${this.baseUrl}/api/v2/solutions/categories/${category.id}/folders`, {
       headers: this.defaultHeaders,
     })
-    this.checkStatus(res)
+    await this.checkStatus(res)
     return (await res.json()) as FreshdeskFolder[]
   }
 
@@ -207,7 +216,7 @@ export class FreshdeskApi {
     const res = await fetch(`${this.baseUrl}/api/v2/solutions/folders/${folder.id}/articles`, {
       headers: this.defaultHeaders,
     })
-    this.checkStatus(res)
+    await this.checkStatus(res)
     return (await res.json()) as FreshdeskArticle[]
   }
 
@@ -226,7 +235,7 @@ export class FreshdeskApi {
         body: JSON.stringify(body),
         headers: this.defaultHeaders,
       })
-      this.checkStatus(res)
+      await this.checkStatus(res)
       return (await res.json()) as FreshdeskCategory
     } catch (err) {
       const httpError = err as HttpError
@@ -237,7 +246,7 @@ export class FreshdeskApi {
           body: JSON.stringify(body),
           headers: this.defaultHeaders,
         })
-        this.checkStatus(res2)
+        await this.checkStatus(res2)
         return (await res2.json()) as FreshdeskCategory
       }
       if (httpError.code === 429) {
@@ -263,7 +272,7 @@ export class FreshdeskApi {
         body: JSON.stringify(body),
         headers: this.defaultHeaders,
       })
-      this.checkStatus(res)
+      await this.checkStatus(res)
       return (await res.json()) as FreshdeskFolder
     } catch (err) {
       const httpError = err as HttpError
@@ -274,7 +283,7 @@ export class FreshdeskApi {
           body: JSON.stringify(body),
           headers: this.defaultHeaders,
         })
-        this.checkStatus(res2)
+        await this.checkStatus(res2)
         return (await res2.json()) as FreshdeskFolder
       }
       if (httpError.code === 429) {
@@ -300,7 +309,7 @@ export class FreshdeskApi {
         body: JSON.stringify(body),
         headers: this.defaultHeaders,
       })
-      this.checkStatus(res)
+      await this.checkStatus(res)
       return (await res.json()) as FreshdeskArticle
     } catch (err) {
       const httpError = err as HttpError
@@ -311,7 +320,7 @@ export class FreshdeskApi {
           body: JSON.stringify(body),
           headers: this.defaultHeaders,
         })
-        this.checkStatus(res2)
+        await this.checkStatus(res2)
         return (await res2.json()) as FreshdeskArticle
       }
       if (httpError.code === 429) {

--- a/scripts/lib/freshdesk-api.mts
+++ b/scripts/lib/freshdesk-api.mts
@@ -147,6 +147,23 @@ export interface FreshdeskSEOData {
 }
 
 /**
+ * A Freshdesk agent, as returned by the `agents/me` endpoint.
+ * @see https://developers.freshdesk.com/api/#me
+ */
+export interface FreshdeskAgent {
+  /** Unique ID of the agent */
+  id: number
+  /** Scope of tickets the agent can access */
+  ticket_scope?: number
+  /** The agent's contact details */
+  contact: {
+    name: string
+    email: string
+    active?: boolean
+  }
+}
+
+/**
  * Wrapper for Freshdesk's REST API
  */
 export class FreshdeskApi {
@@ -218,6 +235,18 @@ export class FreshdeskApi {
     })
     await this.checkStatus(res)
     return (await res.json()) as FreshdeskArticle[]
+  }
+
+  /**
+   * Fetch the agent that the configured API key authenticates as. The account behind the token
+   * determines what the sync may read and write, so surfacing it makes a permission problem (such
+   * as a `403 access_denied` on a specific item) much easier to route to the right person.
+   * @returns the agent's id and contact details
+   */
+  async getAuthenticatedAgent(): Promise<FreshdeskAgent> {
+    const res = await fetch(`${this.baseUrl}/api/v2/agents/me`, { headers: this.defaultHeaders })
+    await this.checkStatus(res)
+    return (await res.json()) as FreshdeskAgent
   }
 
   async updateCategoryTranslation(
@@ -329,6 +358,23 @@ export class FreshdeskApi {
       process.stdout.write(`Error processing id ${id} for locale ${locale}: ${httpError.message}\n`)
       throw err
     }
+  }
+}
+
+/**
+ * Log which agent the given Freshdesk client authenticates as. Never throws: identifying the agent
+ * is a diagnostic aid, so a failure here (for example an invalid token) is reported and swallowed
+ * rather than aborting the caller, which will hit the same problem with a clearer error of its own.
+ * The agent's email is intentionally omitted to keep it out of public CI logs; the name and id are
+ * enough to find the account in Freshdesk.
+ * @param fd - a configured Freshdesk client
+ */
+export const logAuthenticatedAgent = async (fd: FreshdeskApi): Promise<void> => {
+  try {
+    const agent = await fd.getAuthenticatedAgent()
+    console.log(`Freshdesk token authenticated as "${agent.contact.name}" (agent id ${agent.id}).`)
+  } catch (error) {
+    console.warn(`Could not identify the Freshdesk agent for the configured token: ${(error as Error).message}`)
   }
 }
 

--- a/scripts/lib/freshdesk-api.mts
+++ b/scripts/lib/freshdesk-api.mts
@@ -1,4 +1,5 @@
 // interface to FreshDesk Solutions (knowledge base) api
+import { messageOf } from './errors.mts'
 
 /**
  * Extend
@@ -374,7 +375,7 @@ export const logAuthenticatedAgent = async (fd: FreshdeskApi): Promise<void> => 
     const agent = await fd.getAuthenticatedAgent()
     console.log(`Freshdesk token authenticated as "${agent.contact.name}" (agent id ${agent.id}).`)
   } catch (error) {
-    console.warn(`Could not identify the Freshdesk agent for the configured token: ${(error as Error).message}`)
+    console.warn(`Could not identify the Freshdesk agent for the configured token: ${messageOf(error)}`)
   }
 }
 

--- a/scripts/lib/help-utils.mts
+++ b/scripts/lib/help-utils.mts
@@ -2,12 +2,13 @@
  * @file
  * Helper functions for syncing Freshdesk knowledge base articles with Transifex
  */
-import { promises as fsPromises, appendFileSync } from 'fs'
+import { promises as fsPromises } from 'fs'
 import { mkdirp } from 'mkdirp'
 import FreshdeskApi, { FreshdeskArticleCreate, FreshdeskArticleStatus, FreshdeskFolder } from './freshdesk-api.mts'
 import { TransifexStringKeyValueJson, TransifexStringsKeyValueJson, TransifexStrings } from './transifex-formats.mts'
 import { TransifexResourceObject } from './transifex-objects.mts'
 import { txPull, txResourcesObjects, txAvailableLanguages } from './transifex.mts'
+import { emitWarning } from './warnings.mts'
 
 const FD = new FreshdeskApi('https://mitscratch.freshdesk.com', process.env.FRESHDESK_TOKEN ?? '')
 const TX_PROJECT = 'scratch-help'
@@ -44,13 +45,6 @@ const parseIntOrThrow = (str: string, radix: number) => {
     throw new Error(`Could not parse int safely: ${str}`)
   }
   return num
-}
-
-const emitWarning = (warning: string) => {
-  console.warn(warning)
-  if (process.env.WARNINGS_FILE) {
-    appendFileSync(process.env.WARNINGS_FILE, warning + '\n')
-  }
 }
 
 /**

--- a/scripts/lib/help-utils.mts
+++ b/scripts/lib/help-utils.mts
@@ -143,9 +143,13 @@ const serializeNameSave = async (
       let status
       if (resource.attributes.name === 'categoryNames_json') {
         status = await FD.updateCategoryTranslation(id, freshdeskLocale(locale), { name: value })
-      }
-      if (resource.attributes.name === 'folderNames_json') {
+      } else if (resource.attributes.name === 'folderNames_json') {
         status = await FD.updateFolderTranslation(id, freshdeskLocale(locale), { name: value })
+      } else {
+        // Guard against silently dropping an unexpected resource: this function only knows how to
+        // write category and folder names. A new KEYVALUEJSON names resource would otherwise no-op
+        // while still reporting success.
+        throw new Error(`Unexpected names resource "${resource.attributes.name}"; don't know how to save it`)
       }
       if (status === -1) {
         process.exitCode = 1

--- a/scripts/lib/help-utils.mts
+++ b/scripts/lib/help-utils.mts
@@ -4,7 +4,12 @@
  */
 import { promises as fsPromises } from 'fs'
 import { mkdirp } from 'mkdirp'
-import FreshdeskApi, { FreshdeskArticleCreate, FreshdeskArticleStatus, FreshdeskFolder } from './freshdesk-api.mts'
+import FreshdeskApi, {
+  FreshdeskArticleCreate,
+  FreshdeskArticleStatus,
+  FreshdeskFolder,
+  logAuthenticatedAgent,
+} from './freshdesk-api.mts'
 import { TransifexStringKeyValueJson, TransifexStringsKeyValueJson, TransifexStrings } from './transifex-formats.mts'
 import { TransifexResourceObject } from './transifex-objects.mts'
 import { txPull, txResourcesObjects, txAvailableLanguages } from './transifex.mts'
@@ -12,6 +17,13 @@ import { emitWarning } from './warnings.mts'
 
 const FD = new FreshdeskApi('https://mitscratch.freshdesk.com', process.env.FRESHDESK_TOKEN ?? '')
 const TX_PROJECT = 'scratch-help'
+
+/**
+ * Log which agent the configured Freshdesk token authenticates as, to aid in diagnosing permission
+ * problems. Never throws.
+ * @returns a promise that resolves once the agent has been logged
+ */
+export const logFreshdeskAgent = (): Promise<void> => logAuthenticatedAgent(FD)
 
 const freshdeskLocale = (locale: string): string => {
   // map between Transifex locale and Freshdesk. Two letter codes are usually fine

--- a/scripts/lib/help-utils.mts
+++ b/scripts/lib/help-utils.mts
@@ -124,27 +124,38 @@ const serializeNameSave = async (
   warnedKeys: Set<string>,
 ): Promise<void> => {
   for (const [key, value] of Object.entries(strings)) {
-    // key is of the form <name>_<id>
-    const words = key.split('_')
-    const id = parseIntOrThrow(words[words.length - 1], 10)
-    if (!validIds.has(id)) {
-      const warnedKey = `${resource.attributes.name}:${id}`
-      if (!warnedKeys.has(warnedKey)) {
-        warnedKeys.add(warnedKey)
-        emitWarning(
-          `Warning: key "${key}" in Transifex resource "${resource.attributes.name}" refers to Freshdesk id ${id} which no longer exists. Remove this key from the Transifex resource.`,
-        )
+    // Handle each entry independently: a failure on one item (for example a translation the token
+    // is not allowed to write) must not abort the remaining names for this locale.
+    try {
+      // key is of the form <name>_<id>
+      const words = key.split('_')
+      const id = parseIntOrThrow(words[words.length - 1], 10)
+      if (!validIds.has(id)) {
+        const warnedKey = `${resource.attributes.name}:${id}`
+        if (!warnedKeys.has(warnedKey)) {
+          warnedKeys.add(warnedKey)
+          emitWarning(
+            `Warning: key "${key}" in Transifex resource "${resource.attributes.name}" refers to Freshdesk id ${id} which no longer exists. Remove this key from the Transifex resource.`,
+          )
+        }
+        continue
       }
-      continue
-    }
-    let status
-    if (resource.attributes.name === 'categoryNames_json') {
-      status = await FD.updateCategoryTranslation(id, freshdeskLocale(locale), { name: value })
-    }
-    if (resource.attributes.name === 'folderNames_json') {
-      status = await FD.updateFolderTranslation(id, freshdeskLocale(locale), { name: value })
-    }
-    if (status === -1) {
+      let status
+      if (resource.attributes.name === 'categoryNames_json') {
+        status = await FD.updateCategoryTranslation(id, freshdeskLocale(locale), { name: value })
+      }
+      if (resource.attributes.name === 'folderNames_json') {
+        status = await FD.updateFolderTranslation(id, freshdeskLocale(locale), { name: value })
+      }
+      if (status === -1) {
+        process.exitCode = 1
+      }
+    } catch (error) {
+      // The FreshdeskApi update method already logged the specific error. Record the failure so the
+      // job still exits non-zero, then move on to the next entry.
+      process.stdout.write(
+        `Failed to save an entry in ${resource.attributes.name} for ${locale} (key "${key}"): ${(error as Error).message}\n`,
+      )
       process.exitCode = 1
     }
   }
@@ -168,22 +179,30 @@ interface FreshdeskFolderInTransifex {
  */
 const serializeFolderSave = async (json: TransifexStrings<FreshdeskFolderInTransifex>, locale: string) => {
   for (const [idString, value] of Object.entries(json)) {
-    const id = parseIntOrThrow(idString, 10)
-    const body: FreshdeskArticleCreate = {
-      title: value.title.string,
-      description: value.description.string,
-      status: FreshdeskArticleStatus.published,
-    }
-    if (Object.prototype.hasOwnProperty.call(value, 'tags')) {
-      const tags = value.tags.string.split(',')
-      const validTags = tags.filter(tag => tag.length < 33)
-      if (validTags.length !== tags.length) {
-        emitWarning(`Warning: tags too long in ${id} for ${locale}`)
+    // Handle each article independently: a failure on one must not abort the rest for this locale.
+    try {
+      const id = parseIntOrThrow(idString, 10)
+      const body: FreshdeskArticleCreate = {
+        title: value.title.string,
+        description: value.description.string,
+        status: FreshdeskArticleStatus.published,
       }
-      body.tags = validTags
-    }
-    const status = await FD.updateArticleTranslation(id, freshdeskLocale(locale), body)
-    if (status === -1) {
+      if (Object.prototype.hasOwnProperty.call(value, 'tags')) {
+        const tags = value.tags.string.split(',')
+        const validTags = tags.filter(tag => tag.length < 33)
+        if (validTags.length !== tags.length) {
+          emitWarning(`Warning: tags too long in ${id} for ${locale}`)
+        }
+        body.tags = validTags
+      }
+      const status = await FD.updateArticleTranslation(id, freshdeskLocale(locale), body)
+      if (status === -1) {
+        process.exitCode = 1
+      }
+    } catch (error) {
+      // The FreshdeskApi update method already logged the specific error. Record the failure so the
+      // job still exits non-zero, then move on to the next article.
+      process.stdout.write(`Failed to save article ${idString} for ${locale}: ${(error as Error).message}\n`)
       process.exitCode = 1
     }
   }

--- a/scripts/lib/help-utils.mts
+++ b/scripts/lib/help-utils.mts
@@ -4,6 +4,7 @@
  */
 import { promises as fsPromises } from 'fs'
 import { mkdirp } from 'mkdirp'
+import { messageOf } from './errors.mts'
 import FreshdeskApi, {
   FreshdeskArticleCreate,
   FreshdeskArticleStatus,
@@ -158,7 +159,7 @@ const serializeNameSave = async (
       // The FreshdeskApi update method already logged the specific error. Record the failure so the
       // job still exits non-zero, then move on to the next entry.
       process.stdout.write(
-        `Failed to save an entry in ${resource.attributes.name} for ${locale} (key "${key}"): ${(error as Error).message}\n`,
+        `Failed to save an entry in ${resource.attributes.name} for ${locale} (key "${key}"): ${messageOf(error)}\n`,
       )
       process.exitCode = 1
     }
@@ -206,7 +207,7 @@ const serializeFolderSave = async (json: TransifexStrings<FreshdeskFolderInTrans
     } catch (error) {
       // The FreshdeskApi update method already logged the specific error. Record the failure so the
       // job still exits non-zero, then move on to the next article.
-      process.stdout.write(`Failed to save article ${idString} for ${locale}: ${(error as Error).message}\n`)
+      process.stdout.write(`Failed to save article ${idString} for ${locale}: ${messageOf(error)}\n`)
       process.exitCode = 1
     }
   }

--- a/scripts/lib/transifex.mts
+++ b/scripts/lib/transifex.mts
@@ -3,6 +3,7 @@
  * Utilities for interfacing with Transifex API 3.
  */
 import { transifexApi, Collection, JsonApiResource } from '@transifex/api'
+import { messageOf } from './errors.mts'
 import { TransifexStrings } from './transifex-formats.mts'
 import { TransifexLanguageObject, TransifexResourceObject } from './transifex-objects.mts'
 
@@ -33,14 +34,6 @@ const TX_UPLOAD_TIMEOUT_MS = 5 * 60_000
 const TX_DOWNLOAD_TIMEOUT_MS = 60_000
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
-
-/**
- * Extract a human-readable message from a caught value. `catch` values are typed `unknown` and are
- * not guaranteed to be `Error` instances, so read `.message` only when it really is one.
- * @param err - the caught value
- * @returns the error message, or a string representation of a non-Error throw
- */
-const messageOf = (err: unknown): string => (err instanceof Error ? err.message : String(err))
 
 /**
  * Decide whether an error is worth retrying: server-side 5xx, rate limiting (429), or a transient

--- a/scripts/lib/transifex.mts
+++ b/scripts/lib/transifex.mts
@@ -35,6 +35,14 @@ const TX_DOWNLOAD_TIMEOUT_MS = 60_000
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
 /**
+ * Extract a human-readable message from a caught value. `catch` values are typed `unknown` and are
+ * not guaranteed to be `Error` instances, so read `.message` only when it really is one.
+ * @param err - the caught value
+ * @returns the error message, or a string representation of a non-Error throw
+ */
+const messageOf = (err: unknown): string => (err instanceof Error ? err.message : String(err))
+
+/**
  * Decide whether an error is worth retrying: server-side 5xx, rate limiting (429), or a transient
  * network failure. Client errors (4xx other than 429) are not retried — they won't fix themselves.
  * @param err - the thrown error, from the Transifex SDK (`JsonApiException`), `fetch`, or the network stack
@@ -78,7 +86,7 @@ const withRetry = async function <T>(label: string, fn: () => Promise<T>): Promi
       const delay = TX_RETRY_BASE_MS * 2 ** (attempt - 1)
       console.warn(
         `${label}: transient error on attempt ${attempt}/${TX_MAX_TRANSIENT_RETRIES}, ` +
-          `retrying in ${delay}ms: ${(err as Error).message}`,
+          `retrying in ${delay}ms: ${messageOf(err)}`,
       )
       await sleep(delay)
     }
@@ -214,7 +222,7 @@ export const txPull = async function <T>(
         break
       } catch (e) {
         lastError = e
-        console.error(`txPull download attempt ${i + 1} failed for ${resource}/${locale}: ${(e as Error).message}`)
+        console.error(`txPull download attempt ${i + 1} failed for ${resource}/${locale}: ${messageOf(e)}`)
       }
     }
     if (buffer === null) {

--- a/scripts/lib/transifex.mts
+++ b/scripts/lib/transifex.mts
@@ -17,6 +17,86 @@ transifexApi.setup({
   auth: process.env.TX_TOKEN,
 })
 
+/** Base delay for exponential backoff between transient-error retries, in milliseconds. */
+const TX_RETRY_BASE_MS = 1_000
+/** Maximum number of attempts for an operation that fails with a transient (retryable) error. */
+const TX_MAX_TRANSIENT_RETRIES = 5
+/** How often to poll an async upload for completion, in milliseconds. */
+const TX_UPLOAD_POLL_INTERVAL_MS = 2_000
+/**
+ * Overall budget for a single async upload to reach a terminal state, in milliseconds.
+ * This bounds the poll loop so a stuck upload fails fast (with a clear message) instead of
+ * polling forever — the workflow's `timeout-minutes` is only a last-resort backstop.
+ */
+const TX_UPLOAD_TIMEOUT_MS = 5 * 60_000
+/** Per-request timeout for downloading a resource from the CDN, in milliseconds. */
+const TX_DOWNLOAD_TIMEOUT_MS = 60_000
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * Decide whether an error is worth retrying: server-side 5xx, rate limiting (429), or a transient
+ * network failure. Client errors (4xx other than 429) are not retried — they won't fix themselves.
+ * @param err - the thrown error, from the Transifex SDK (`JsonApiException`), `fetch`, or the network stack
+ * @returns true if retrying the same operation might succeed
+ */
+const isTransientError = (err: unknown): boolean => {
+  const e = (err ?? {}) as { statusCode?: number; status?: number; code?: string; cause?: { code?: string } }
+  const status = e.statusCode ?? e.status
+  if (typeof status === 'number') {
+    return status === 429 || (status >= 500 && status < 600)
+  }
+  const code = e.code ?? e.cause?.code
+  return (
+    code === 'ECONNRESET' ||
+    code === 'ECONNREFUSED' ||
+    code === 'ETIMEDOUT' ||
+    code === 'EAI_AGAIN' ||
+    code === 'UND_ERR_SOCKET' ||
+    code === 'UND_ERR_CONNECT_TIMEOUT'
+  )
+}
+
+/**
+ * Run an async operation, retrying with exponential backoff when it fails with a transient error.
+ * Non-transient errors (for example a 404) are re-thrown immediately so callers can handle them.
+ * @template T - the resolved type of the operation
+ * @param label - short description of the operation, used in retry log lines
+ * @param fn - the operation to run; called once per attempt
+ * @returns the resolved value of `fn`
+ */
+const withRetry = async function <T>(label: string, fn: () => Promise<T>): Promise<T> {
+  let lastError: unknown
+  for (let attempt = 1; attempt <= TX_MAX_TRANSIENT_RETRIES; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastError = err
+      if (!isTransientError(err) || attempt === TX_MAX_TRANSIENT_RETRIES) {
+        throw err
+      }
+      const delay = TX_RETRY_BASE_MS * 2 ** (attempt - 1)
+      console.warn(
+        `${label}: transient error on attempt ${attempt}/${TX_MAX_TRANSIENT_RETRIES}, ` +
+          `retrying in ${delay}ms: ${(err as Error).message}`,
+      )
+      await sleep(delay)
+    }
+  }
+  // Unreachable: the loop either returns or throws, but TypeScript can't prove it.
+  throw lastError
+}
+
+/**
+ * The subset of an async-upload resource instance that we poll. The SDK's generated types model
+ * `reload` as requiring an `include` argument, but at runtime it is optional; this shape lets us
+ * call `reload()` with no arguments while staying type-checked.
+ */
+interface AsyncUploadResource {
+  get(key: string): unknown
+  reload(): Promise<void>
+}
+
 /*
  * The Transifex JS API wraps the Transifex JSON API, and is built around the concept of a `Collection`.
  * A `Collection` begins as a URL builder: methods like `filter` and `sort` add query parameters to the URL.
@@ -111,24 +191,37 @@ export const txPull = async function <T>(
 ): Promise<TransifexStrings<T>> {
   let buffer: string | null = null
   try {
-    const url = await getResourceLocation(project, resource, locale, mode)
+    // Creating the download event itself polls Transifex until the file is ready; retry transient
+    // failures (5xx / network blips) so one bad response doesn't sink the whole pull.
+    const url = await withRetry(`txPull download event for ${resource}/${locale}`, () =>
+      getResourceLocation(project, resource, locale, mode),
+    )
+    let lastError: unknown
     for (let i = 0; i < 5; i++) {
       if (i > 0) {
-        console.log(`Retrying txPull download after ${i} failed attempt(s)`)
+        const delay = TX_RETRY_BASE_MS * 2 ** (i - 1)
+        console.log(
+          `Retrying txPull download for ${resource}/${locale} after ${i} failed attempt(s); waiting ${delay}ms`,
+        )
+        await sleep(delay)
       }
       try {
-        const response = await fetch(url)
+        const response = await fetch(url, { signal: AbortSignal.timeout(TX_DOWNLOAD_TIMEOUT_MS) })
         if (!response.ok) {
-          throw new Error(`Failed to download resource: ${response.statusText}`)
+          throw new Error(`Failed to download resource: HTTP ${response.status} ${response.statusText}`)
         }
         buffer = await response.text()
         break
       } catch (e) {
-        console.error(e, { project, resource, locale, buffer })
+        lastError = e
+        console.error(`txPull download attempt ${i + 1} failed for ${resource}/${locale}: ${(e as Error).message}`)
       }
     }
-    if (!buffer) {
-      throw Error(`txPull download failed after 5 retries: ${url}`)
+    if (buffer === null) {
+      throw new Error(
+        `txPull download failed after 5 attempts for ${resource}/${locale} (${url}): ` +
+          `${(lastError as Error | undefined)?.message ?? 'unknown error'}`,
+      )
     }
     return JSON.parse(buffer) as TransifexStrings<T>
   } catch (e) {
@@ -205,10 +298,42 @@ export const txPush = async function (project: string, resource: string, sourceS
     },
   }
 
-  await transifexApi.ResourceStringsAsyncUpload.upload({
-    resource: resourceObj,
-    content: JSON.stringify(sourceStrings),
-  })
+  // `ResourceStringsAsyncUpload.upload()` creates the upload and then polls until its status is
+  // `succeeded`. That poll has no timeout and no exit for a `failed` status, so a rejected upload
+  // (or one stuck in `pending`) loops forever — historically until the CI job's 6-hour limit, and
+  // any transient 502 on a poll crashed the whole job with an unhelpful stack trace. We do the
+  // create-then-poll ourselves so we can bound it, retry transient blips, and surface the actual
+  // reason an upload failed.
+  const upload = (await withRetry(`txPush create upload for "${resource}"`, () =>
+    transifexApi.ResourceStringsAsyncUpload.create({
+      resource: resourceObj,
+      content: JSON.stringify(sourceStrings),
+      content_encoding: 'text',
+      // The generated type insists on id/attributes/relationships/links, but the upload resource
+      // takes this flatter shape — the same one `ResourceStringsAsyncUpload.upload()` passes through.
+    } as unknown as Parameters<typeof transifexApi.ResourceStringsAsyncUpload.create>[0]),
+  )) as unknown as AsyncUploadResource
+
+  const deadline = Date.now() + TX_UPLOAD_TIMEOUT_MS
+  for (;;) {
+    const status = upload.get('status') as string | undefined
+    if (status === 'succeeded') {
+      return
+    }
+    if (status === 'failed') {
+      // On failure the upload carries `errors` (and sometimes `details`) explaining why.
+      const errorInfo = upload.get('errors') ?? upload.get('details') ?? 'no error detail provided'
+      throw new Error(`Transifex upload failed for resource "${resource}": ${JSON.stringify(errorInfo)}`)
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Transifex upload for resource "${resource}" did not reach a terminal state within ` +
+          `${TX_UPLOAD_TIMEOUT_MS / 1000}s (last status: ${status ?? 'unknown'}).`,
+      )
+    }
+    await sleep(TX_UPLOAD_POLL_INTERVAL_MS)
+    await withRetry(`txPush poll upload for "${resource}"`, () => upload.reload())
+  }
 }
 
 /**

--- a/scripts/lib/transifex.mts
+++ b/scripts/lib/transifex.mts
@@ -42,7 +42,19 @@ const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(r
  * @returns true if retrying the same operation might succeed
  */
 const isTransientError = (err: unknown): boolean => {
-  const e = (err ?? {}) as { statusCode?: number; status?: number; code?: string; cause?: { code?: string } }
+  const e = (err ?? {}) as {
+    statusCode?: number
+    status?: number
+    code?: string
+    name?: string
+    cause?: { code?: string }
+  }
+  // A `fetch` aborted by `AbortSignal.timeout` rejects with a `TimeoutError` that carries no status
+  // or code; the only abort in this module is that timeout, so treat it (and a bare abort) as worth
+  // retrying.
+  if (e.name === 'TimeoutError' || e.name === 'AbortError') {
+    return true
+  }
   const status = e.statusCode ?? e.status
   if (typeof status === 'number') {
     return status === 429 || (status >= 500 && status < 600)
@@ -209,13 +221,23 @@ export const txPull = async function <T>(
       try {
         const response = await fetch(url, { signal: AbortSignal.timeout(TX_DOWNLOAD_TIMEOUT_MS) })
         if (!response.ok) {
-          throw new Error(`Failed to download resource: HTTP ${response.status} ${response.statusText}`)
+          const err = new Error(
+            `Failed to download resource: HTTP ${response.status} ${response.statusText}`,
+          ) as Error & { status: number }
+          err.status = response.status
+          throw err
         }
         buffer = await response.text()
         break
       } catch (e) {
         lastError = e
         console.error(`txPull download attempt ${i + 1} failed for ${resource}/${locale}: ${messageOf(e)}`)
+        // Only 5xx / 429 / network / timeout failures are worth retrying. A non-transient failure
+        // (for example a 403 or 404) won't fix itself, so fail fast and surface the real cause
+        // instead of burning the remaining attempts.
+        if (!isTransientError(e)) {
+          throw e
+        }
       }
     }
     if (buffer === null) {

--- a/scripts/lib/warnings.mts
+++ b/scripts/lib/warnings.mts
@@ -1,0 +1,19 @@
+/**
+ * @file
+ * Shared helper for reporting non-fatal problems during help sync.
+ */
+import { appendFileSync } from 'fs'
+
+/**
+ * Log a warning to the console and, when the `WARNINGS_FILE` environment variable is set, append it
+ * to that file. CI reads the file after the sync to surface warnings in the job summary and to send
+ * a notification, so a warning is the right tool for a problem worth a human's attention that should
+ * not fail the run (for example, a resource we deliberately skip).
+ * @param warning - the warning message; a trailing newline is added when written to the file
+ */
+export const emitWarning = (warning: string): void => {
+  console.warn(warning)
+  if (process.env.WARNINGS_FILE) {
+    appendFileSync(process.env.WARNINGS_FILE, warning + '\n')
+  }
+}

--- a/scripts/lib/warnings.mts
+++ b/scripts/lib/warnings.mts
@@ -3,6 +3,7 @@
  * Shared helper for reporting non-fatal problems during help sync.
  */
 import { appendFileSync } from 'fs'
+import { messageOf } from './errors.mts'
 
 /**
  * Log a warning to the console and, when the `WARNINGS_FILE` environment variable is set, append it
@@ -14,6 +15,12 @@ import { appendFileSync } from 'fs'
 export const emitWarning = (warning: string): void => {
   console.warn(warning)
   if (process.env.WARNINGS_FILE) {
-    appendFileSync(process.env.WARNINGS_FILE, warning + '\n')
+    // The file write is best-effort: emitWarning is the non-fatal path (often called from a catch
+    // block), so a failed append must not turn a warning into a crash.
+    try {
+      appendFileSync(process.env.WARNINGS_FILE, warning + '\n')
+    } catch (error) {
+      console.warn(`Could not append to WARNINGS_FILE "${process.env.WARNINGS_FILE}": ${messageOf(error)}`)
+    }
   }
 }

--- a/scripts/tx-pull-help-names.mts
+++ b/scripts/tx-pull-help-names.mts
@@ -3,7 +3,7 @@
  * @file
  * Script to pull scratch-help translations from transifex and push to FreshDesk.
  */
-import { getInputs, getValidFreshdeskIds, saveItem, localizeNames } from './lib/help-utils.mts'
+import { getInputs, getValidFreshdeskIds, saveItem, localizeNames, logFreshdeskAgent } from './lib/help-utils.mts'
 
 const args = process.argv.slice(2)
 
@@ -21,6 +21,8 @@ if (!process.env.TX_TOKEN || !process.env.FRESHDESK_TOKEN || args.length > 0) {
   process.stdout.write(usage)
   process.exit(1)
 }
+
+await logFreshdeskAgent()
 
 const [{ languages, names }, { validCategoryIds, validFolderIds }] = await Promise.all([
   getInputs(),

--- a/scripts/tx-push-help.mts
+++ b/scripts/tx-push-help.mts
@@ -80,8 +80,9 @@ const txPushResource = async (
     slug: name,
     name: name,
     i18nType: type,
-    priority: 0, // default to normal priority
-    content: articles,
+    // `txCreateResource` reads `sourceStrings` (not `content`); passing the wrong key left a newly
+    // created resource empty until a later run populated it.
+    sourceStrings: articles,
   }
 
   try {

--- a/scripts/tx-push-help.mts
+++ b/scripts/tx-push-help.mts
@@ -6,6 +6,7 @@
 import FreshdeskApi, { FreshdeskArticleStatus, FreshdeskCategory, FreshdeskFolder } from './lib/freshdesk-api.mts'
 import { TransifexStringsKeyValueJson, TransifexStringsStructuredJson } from './lib/transifex-formats.mts'
 import { txPush, txCreateResource, JsonApiException } from './lib/transifex.mts'
+import { emitWarning } from './lib/warnings.mts'
 
 const args = process.argv.slice(2)
 
@@ -50,6 +51,15 @@ const txPushResource = async (
   articles: TransifexStringsStructuredJson | TransifexStringsKeyValueJson,
   type: string,
 ) => {
+  // Transifex rejects an upload with no extractable strings (`parse_error: No strings could be
+  // extracted`). That used to leave the upload stuck in a non-`succeeded` state forever, hanging
+  // the whole sync. An empty resource almost always means a Freshdesk folder with no published
+  // articles, which is a content situation rather than a sync failure: warn and skip it.
+  if (Object.keys(articles).length === 0) {
+    emitWarning(`Skipping Transifex resource "${name}": no strings to push (empty content).`)
+    return
+  }
+
   const resourceData = {
     slug: name,
     name: name,

--- a/scripts/tx-push-help.mts
+++ b/scripts/tx-push-help.mts
@@ -103,9 +103,9 @@ const txPushResource = async (
  * @param categories - array of categories the folders belong to
  * @returns flattened list of folders from all requested categories
  */
-const getFolders = async (categories: FreshdeskCategory[]) => {
+const getFolders = async (categories: FreshdeskCategory[]): Promise<FreshdeskFolder[]> => {
   const categoryFolders = await Promise.all(
-    categories.map(async category => {
+    categories.map(async (category): Promise<FreshdeskFolder[]> => {
       try {
         return await FD.listFolders(category)
       } catch (error) {
@@ -114,7 +114,7 @@ const getFolders = async (categories: FreshdeskCategory[]) => {
       }
     }),
   )
-  return ([] as FreshdeskCategory[]).concat(...categoryFolders)
+  return categoryFolders.flat()
 }
 
 /**
@@ -150,7 +150,7 @@ const saveArticles = async (folder: FreshdeskFolder) => {
 /**
  * @param folders - Array of folders containing articles to be saved
  */
-const saveArticleFolders = async (folders: FreshdeskCategory[]) => {
+const saveArticleFolders = async (folders: FreshdeskFolder[]) => {
   await Promise.all(folders.map(folder => saveArticles(folder)))
 }
 

--- a/scripts/tx-push-help.mts
+++ b/scripts/tx-push-help.mts
@@ -3,7 +3,12 @@
  * @file
  * Script get Knowledge base articles from Freshdesk and push them to transifex.
  */
-import FreshdeskApi, { FreshdeskArticleStatus, FreshdeskCategory, FreshdeskFolder } from './lib/freshdesk-api.mts'
+import FreshdeskApi, {
+  FreshdeskArticleStatus,
+  FreshdeskCategory,
+  FreshdeskFolder,
+  logAuthenticatedAgent,
+} from './lib/freshdesk-api.mts'
 import { TransifexStringsKeyValueJson, TransifexStringsStructuredJson } from './lib/transifex-formats.mts'
 import { txPush, txCreateResource, JsonApiException } from './lib/transifex.mts'
 import { emitWarning } from './lib/warnings.mts'
@@ -30,6 +35,17 @@ const TX_PROJECT = 'scratch-help'
 
 const categoryNames: TransifexStringsKeyValueJson = {}
 const folderNames: TransifexStringsKeyValueJson = {}
+
+// Collect per-resource failures instead of aborting on the first one, so a single failing folder or
+// category (for example one the token cannot access) still lets every other resource sync. The
+// script fails at the end if anything meaningful failed, so a persistent problem is surfaced for
+// investigation rather than silently dropped.
+const failures: { context: string; message: string }[] = []
+const recordFailure = (context: string, error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`Error: ${context}: ${message}`)
+  failures.push({ context, message })
+}
 
 /**
  * Generate a transifex resource slug from the name and ID of a Freshdesk object.
@@ -88,7 +104,16 @@ const txPushResource = async (
  * @returns flattened list of folders from all requested categories
  */
 const getFolders = async (categories: FreshdeskCategory[]) => {
-  const categoryFolders = await Promise.all(categories.map(category => FD.listFolders(category)))
+  const categoryFolders = await Promise.all(
+    categories.map(async category => {
+      try {
+        return await FD.listFolders(category)
+      } catch (error) {
+        recordFailure(`list folders for category "${category.name}" (id ${category.id})`, error)
+        return []
+      }
+    }),
+  )
   return ([] as FreshdeskCategory[]).concat(...categoryFolders)
 }
 
@@ -97,7 +122,8 @@ const getFolders = async (categories: FreshdeskCategory[]) => {
  * @param folder - The folder object
  */
 const saveArticles = async (folder: FreshdeskFolder) => {
-  await FD.listArticles(folder).then(async json => {
+  try {
+    const json = await FD.listArticles(folder)
     const txArticles = json.reduce((strings: TransifexStringsStructuredJson, current) => {
       if (current.status === FreshdeskArticleStatus.published) {
         strings[String(current.id)] = {
@@ -116,7 +142,9 @@ const saveArticles = async (folder: FreshdeskFolder) => {
     }, {})
     process.stdout.write(`Push ${folder.name} articles to Transifex\n`)
     await txPushResource(`${makeTxSlug(folder)}_json`, txArticles, 'STRUCTURED_JSON')
-  })
+  } catch (error) {
+    recordFailure(`folder "${folder.name}" (id ${folder.id})`, error)
+  }
 }
 
 /**
@@ -143,12 +171,25 @@ const syncSources = async () => {
       })
       process.stdout.write('Push category and folder names to Transifex\n')
       await Promise.all([
-        txPushResource('categoryNames_json', categoryNames, 'KEYVALUEJSON'),
-        txPushResource('folderNames_json', folderNames, 'KEYVALUEJSON'),
+        txPushResource('categoryNames_json', categoryNames, 'KEYVALUEJSON').catch(error =>
+          recordFailure('categoryNames_json', error),
+        ),
+        txPushResource('folderNames_json', folderNames, 'KEYVALUEJSON').catch(error =>
+          recordFailure('folderNames_json', error),
+        ),
       ])
       return data
     })
     .then(saveArticleFolders)
 }
 
+await logAuthenticatedAgent(FD)
 await syncSources()
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} resource(s) failed to push to Transifex:`)
+  for (const failure of failures) {
+    console.error(`  - ${failure.context}: ${failure.message}`)
+  }
+  process.exitCode = 1
+}


### PR DESCRIPTION
### Resolves

- No tracked issue. Fixes the recurring failures of the `Daily Help Update` scheduled workflow, which had been ending either as a fast crash on a Transifex 502 or a six hour job cancellation (example runs: [27810215828](https://github.com/scratchfoundation/scratch-l10n/actions/runs/27810215828), [28006748291](https://github.com/scratchfoundation/scratch-l10n/actions/runs/28006748291), [26935165394](https://github.com/scratchfoundation/scratch-l10n/actions/runs/26935165394)).

### Proposed Changes

The sync had been failing every day, and the logs gave almost nothing to go on. Investigating it turned up a chain of problems, each hidden behind the previous one. The changes here fix the ones that live in this repo and make the remaining Freshdesk side problem obvious and non blocking.

**Root cause of the hangs (the 6 hour timeouts).** The Transifex client's `ResourceStringsAsyncUpload.upload()` creates an async upload and then polls until the status is `succeeded`, with no timeout and no exit for a `failed` status. When an upload never reached `succeeded` the poll looped until the runner's 6 hour limit; when a poll hit a transient 502 it crashed the job with an unhandled rejection and no useful message. The commit it ran against was irrelevant, which is why the same commit produced both a 3 minute crash and a 6 hour cancellation on different days.

- `txPush` now does the create then poll itself, so it stops on a `failed` status and throws with the upload's reported `errors`, bounds the wait with a deadline (fails fast on a stuck upload), and retries transient errors (5xx, 429, network blips) with backoff. `txPull`'s download path gets the same retry/backoff and clearer per resource errors, plus a per request download timeout. A `timeout-minutes` backstop was also added to the job.

**Empty resources.** A Freshdesk folder with no published articles reduces to empty content, which Transifex rejects with `parse_error: No strings could be extracted` (this is what used to hang the upload). Such resources are now skipped with a warning instead of pushed.

**Better error reporting.** `FreshdeskApi` error messages now include the response body, where Freshdesk reports the actual reason for a failure. This is what turned an opaque `HTTP 403` into `access_denied`, and it is generally useful for future debugging.

**Resilience (update what it can, fail on real problems).** Both the push and the pull back now attempt every item and report failures at the end rather than aborting on the first one. In particular, the pull back write loops used to bail on the first hard error, silently skipping every remaining name or article for that locale; with a stable key order the same items were skipped on every run. Each entry now runs independently, so one unwritable item no longer starves the rest, and the job still exits non zero when something genuinely failed.

**Diagnosability.** Each run now logs which Freshdesk account the API key authenticates as, so a permission problem can be routed to the right account. (The account email is intentionally omitted from the log.)

**Known remaining issue (Freshdesk side, intentionally left failing).** Two Help Center items, the "Questions about Scratch" category and its "Accessibility" folder, return `access_denied` when the sync writes their translated names. This is not a code problem: the token authenticates fine and writes every other item, but those two have a translation left in a broken state after the category was renamed in English (the other language names were never carried over). Repairing them, or running the sync under an account with sufficient access, is a Freshdesk side fix. The job is left failing on these on purpose so the problem stays visible until it is resolved.

### Follow ups (not in this PR)

- `daily-tx-pull.yml` has no `timeout-minutes` and relies on the same unbounded SDK download poll, so it carries the same hang exposure.
- The push fan out could route through the existing `poolMap` to cap concurrent Transifex connections.
- Transifex name slugs are built from name plus id, so a rename churns keys and orphans translations; keying by id would make renames graceful, but that is a larger change with a migration.
