### PR TITLE
Make the help article tag-length warning actionable

### DIFF
--- a/scripts/lib/help-utils.mts
+++ b/scripts/lib/help-utils.mts
@@ -194,9 +194,16 @@ const serializeFolderSave = async (json: TransifexStrings<FreshdeskFolderInTrans
       }
       if (Object.prototype.hasOwnProperty.call(value, 'tags')) {
         const tags = value.tags.string.split(',')
+        // Freshdesk rejects tags longer than 32 characters, so drop them rather than fail the write.
         const validTags = tags.filter(tag => tag.length < 33)
-        if (validTags.length !== tags.length) {
-          emitWarning(`Warning: tags too long in ${id} for ${locale}`)
+        const droppedTags = tags.filter(tag => tag.length >= 33)
+        if (droppedTags.length > 0) {
+          emitWarning(
+            `Dropping ${droppedTags.length} tag(s) over Freshdesk's 32-character limit for article ${id} ` +
+              `(${locale}); shorten them in Transifex: ${droppedTags
+                .map(tag => `"${tag}" (${tag.length} chars)`)
+                .join(', ')}.`,
+          )
         }
         body.tags = validTags
       }


### PR DESCRIPTION
### Proposed Changes

Article tags longer than Freshdesk's 32-character limit are dropped from the
write so the sync doesn't fail on them. The warning that flagged this printed
only the article id and locale (`tags too long in <id> for <locale>`), which
wasn't enough to fix the source data.

Name each dropped tag and its length, and point at Transifex as the place to
shorten it, so someone reading the log can act on it. No behavior change.
