### PR TITLE
Remove unused p-limit and p-queue dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,8 +46,6 @@
         "jshint": "2.13.6",
         "json": "^9.0.6",
         "jsonlint": "1.6.3",
-        "p-limit": "2.3.0",
-        "p-queue": "3.2.0",
         "prettier": "3.9.6",
         "rimraf": "2.7.1",
         "scratch-semantic-release-config": "4.0.1",
@@ -17715,16 +17713,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-queue": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-3.2.0.tgz",
-      "integrity": "sha512-D2OjWeETS1Bjov7d82VclyMRigjZtMdALWV04u0H2zPvV3sYC8f6sYBgQ2Z0OHoBGUYh9S8cHtJqMAO8xaHEwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/p-reduce": {

--- a/package.json
+++ b/package.json
@@ -81,8 +81,6 @@
     "jshint": "2.13.6",
     "json": "^9.0.6",
     "jsonlint": "1.6.3",
-    "p-limit": "2.3.0",
-    "p-queue": "3.2.0",
     "prettier": "3.9.6",
     "rimraf": "2.7.1",
     "scratch-semantic-release-config": "4.0.1",


### PR DESCRIPTION
### Proposed Changes

Remove `p-limit` and `p-queue` from devDependencies. Neither is imported
anywhere in the repo; both were added in 2018 alongside automation scripts that
used the `async` library for concurrency instead, and nothing has referenced
them since. Removing them stops Renovate from maintaining two dependencies the
project doesn't use.

`p-limit` remains in the lockfile as a transitive dependency of other tooling;
this only drops the unused direct entries.
