### PR TITLE
Pace Freshdesk writes to the server's advertised rate limit

### DIFF
--- a/scripts/lib/freshdesk-api.mts
+++ b/scripts/lib/freshdesk-api.mts
@@ -1,5 +1,6 @@
 // interface to FreshDesk Solutions (knowledge base) api
 import { messageOf } from './errors.mts'
+import { emitWarning } from './warnings.mts'
 
 /**
  * Extend
@@ -164,6 +165,68 @@ export interface FreshdeskAgent {
   }
 }
 
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+/** Interval used before the server has told us its limit, in ms (conservative, avoids an opening burst). */
+const FD_START_INTERVAL_MS = 300
+/** Never pace faster than this, even if the advertised limit would allow it, in milliseconds. */
+const FD_MIN_REQUEST_INTERVAL_MS = 100
+/** Ceiling on the interval the backoff will grow to, in milliseconds. */
+const FD_MAX_REQUEST_INTERVAL_MS = 10_000
+/** Fraction of the advertised per-minute budget we aim to use, leaving headroom for bursts and other clients. */
+const FD_RATE_SAFETY_FACTOR = 0.75
+/** When the advertised remaining budget drops to this fraction of the total, pause to let it refill. */
+const FD_LOW_REMAINING_FRACTION = 0.1
+/** How long to hold the schedule when the remaining budget runs low, in milliseconds. */
+const FD_LOW_REMAINING_PAUSE_MS = 3_000
+/** Extra multiplier applied to the interval on a 429, a safety net for when the headers under-report. */
+const FD_RATE_LIMIT_BACKOFF_FACTOR = 1.5
+/** Maximum attempts (the initial request plus retries) for a single request that keeps getting 429ed. */
+const FD_MAX_RATE_LIMIT_ATTEMPTS = 5
+/** Fallback wait when a 429 arrives without a usable `Retry-After` header, in milliseconds. */
+const FD_DEFAULT_RETRY_AFTER_MS = 30_000
+/**
+ * Cap on how long we will actually wait for a single `Retry-After`, in milliseconds. Freshdesk can
+ * return a punitive multi-minute delay once it decides a client is abusing the API; honoring that
+ * verbatim would hang the job past its timeout. We cap the wait so the run fails fast and reports
+ * instead. Correct pacing should keep us from ever earning such a penalty in the first place.
+ */
+const FD_MAX_RETRY_AFTER_MS = 120_000
+
+/**
+ * Parse a `Retry-After` header into milliseconds. Freshdesk sends a delta in seconds, but the HTTP
+ * spec also allows an HTTP-date, so both forms are handled.
+ * @param value - the raw header value, or null if absent
+ * @returns the delay in milliseconds, or null if the header was missing or unparseable
+ */
+const parseRetryAfterMs = (value: string | null): number | null => {
+  if (!value) {
+    return null
+  }
+  const seconds = Number(value)
+  if (Number.isFinite(seconds)) {
+    // A negative delay is malformed; fall back to the default (null) rather than retrying immediately.
+    return seconds < 0 ? null : seconds * 1000
+  }
+  const dateMs = Date.parse(value)
+  return Number.isNaN(dateMs) ? null : Math.max(0, dateMs - Date.now())
+}
+
+/**
+ * Parse a non-negative integer rate-limit header (for example `X-RateLimit-Total`).
+ * @param value - the raw header value, or null if absent
+ * @returns the parsed value, or null if the header was missing or not a finite number
+ */
+const parseIntHeader = (value: string | null): number | null => {
+  if (!value) {
+    return null
+  }
+  const n = Number(value)
+  // Reject anything that isn't a whole, non-negative count: this value drives request pacing, so a
+  // stray decimal or negative from a malformed header should fall back to the defaults, not skew it.
+  return Number.isInteger(n) && n >= 0 ? n : null
+}
+
 /**
  * Wrapper for Freshdesk's REST API
  */
@@ -171,7 +234,25 @@ export class FreshdeskApi {
   baseUrl: string
   private _auth: string
   defaultHeaders: { 'Content-Type': string; Authorization: string }
-  rateLimited: boolean
+  /**
+   * Current minimum spacing between request starts, in milliseconds, shared across every concurrent
+   * caller. Starts conservative and is set from the server's advertised rate-limit headers once they
+   * are seen (see {@link applyRateHeaders}); a 429 nudges it up as a safety net. This is what keeps
+   * the fan-out over folders and locales under the limit.
+   */
+  private requestIntervalMs = FD_START_INTERVAL_MS
+  /** Serializes request starts: each `gate()` call chains onto this so only one is timed at a time. */
+  private queue: Promise<void> = Promise.resolve()
+  /** Timestamp (ms) when the previous request actually started, used to space the next one. */
+  private lastRequestStart = 0
+  /** Timestamp (ms) before which no request may start; set by a 429 or a low remaining-budget signal. */
+  private pauseUntil = 0
+  /** Whether the server's advertised limit has been logged yet (logged once, to aid diagnosis). */
+  private limitLogged = false
+  /** Count of 429 responses seen this run; a nonzero value means the limiter had to back off. */
+  rateLimitHits = 0
+  /** Whether the one-time "rate limiting activated" warning has been emitted this run. */
+  private rateLimitReported = false
 
   constructor(baseUrl: string, apiKey: string) {
     this.baseUrl = baseUrl
@@ -180,7 +261,114 @@ export class FreshdeskApi {
       'Content-Type': 'application/json',
       Authorization: this._auth,
     }
-    this.rateLimited = false
+  }
+
+  /**
+   * Wait for this request's turn. Requests are serialized on a single queue and each starts at least
+   * `requestIntervalMs` after the previous one (and never before {@link pauseUntil}). The wait is
+   * computed when the request reaches the front of the queue — not reserved up front — so an interval
+   * change from a fresh rate-limit header takes effect immediately. That is what keeps the fan-out
+   * over folders and locales under the limit without a burst locking in a too-fast schedule.
+   * @returns a promise that resolves when it is this request's turn to start
+   */
+  private async gate(): Promise<void> {
+    const run = this.queue.then(async () => {
+      const target = Math.max(this.lastRequestStart + this.requestIntervalMs, this.pauseUntil)
+      const wait = target - Date.now()
+      if (wait > 0) {
+        await sleep(wait)
+      }
+      this.lastRequestStart = Date.now()
+    })
+    // Keep the chain alive whether or not the timing step rejects (it shouldn't, but be safe).
+    this.queue = run.catch(() => undefined)
+    return run
+  }
+
+  /**
+   * Steer pacing from Freshdesk's advertised rate-limit headers so we throttle *before* hitting the
+   * wall rather than only reacting to 429s. Freshdesk returns `X-RateLimit-Total` (the per-minute
+   * budget) and `X-RateLimit-Remaining` on every response: we pace to a safe fraction of the budget
+   * and pause as the remaining budget runs low. When the headers are absent the interval is left
+   * alone and we fall back to the 429 backoff.
+   * @param headers - the response headers to read the advertised limits from
+   */
+  private applyRateHeaders(headers: Headers): void {
+    const total = parseIntHeader(headers.get('X-RateLimit-Total'))
+    if (total === null || total <= 0) {
+      return
+    }
+    // Aim for a fraction of the budget: interval = one minute / (budget * safety).
+    const target = 60_000 / (total * FD_RATE_SAFETY_FACTOR)
+    this.requestIntervalMs = Math.min(Math.max(target, FD_MIN_REQUEST_INTERVAL_MS), FD_MAX_REQUEST_INTERVAL_MS)
+    if (!this.limitLogged) {
+      this.limitLogged = true
+      console.log(
+        `Freshdesk advertised rate limit: ${total}/min; pacing requests ` +
+          `~${Math.round(this.requestIntervalMs)}ms apart.`,
+      )
+    }
+    const remaining = parseIntHeader(headers.get('X-RateLimit-Remaining'))
+    if (remaining !== null && remaining <= total * FD_LOW_REMAINING_FRACTION) {
+      // Budget nearly exhausted: hold the shared schedule briefly so the window can refill before we
+      // spend the last of it and trip a 429.
+      this.pauseUntil = Math.max(this.pauseUntil, Date.now() + FD_LOW_REMAINING_PAUSE_MS)
+    }
+  }
+
+  /**
+   * Perform a fetch through the rate limiter: paced against the shared schedule, and transparently
+   * retried on 429 while honoring `Retry-After`. Any non-429 response (success or a real error) is
+   * returned as-is for the caller's {@link checkStatus} to interpret; a 429 that survives every
+   * retry is likewise returned so it surfaces as a genuine, reported failure rather than a silent
+   * skip. Only rate limiting is handled here — other transient failures keep their existing behavior.
+   * @param url - absolute endpoint to call
+   * @param init - method, body, and headers for the fetch
+   * @returns the final response
+   */
+  private async request(url: string, init: RequestInit): Promise<Response> {
+    for (let attempt = 1; ; attempt++) {
+      await this.gate()
+      const res = await fetch(url, init)
+      // Learn the server's limit from every response (success or 429) and pace to it.
+      this.applyRateHeaders(res.headers)
+      if (res.status !== 429) {
+        return res
+      }
+      this.rateLimitHits++
+      // Surface the first back-off through the shared warnings channel (job summary + Slack), once
+      // per run, so a job that recovers and stays green still flags that it is brushing the limit.
+      if (!this.rateLimitReported) {
+        this.rateLimitReported = true
+        emitWarning(
+          'Freshdesk rate limiting was encountered during the help sync. Requests are being paced ' +
+            'and retried (honoring Retry-After), so the run should still complete; if this recurs, ' +
+            'consider reducing request volume or raising the Freshdesk rate limit.',
+        )
+      }
+      const requested = parseRetryAfterMs(res.headers.get('Retry-After')) ?? FD_DEFAULT_RETRY_AFTER_MS
+      // Cap the honored wait so a punitive multi-minute Retry-After can't hang the job; give up
+      // rather than sleep past the timeout. Return the 429 with its body still intact so
+      // checkStatus can read and surface Freshdesk's actual reason for the failure.
+      if (requested > FD_MAX_RETRY_AFTER_MS || attempt >= FD_MAX_RATE_LIMIT_ATTEMPTS) {
+        return res
+      }
+      // We are going to retry and abandon this response, so drain its body now to free the socket
+      // before we wait. (The give-up paths above deliberately leave it unread for checkStatus.)
+      await res.text().catch(() => undefined)
+      // Safety net on top of the header-driven pacing: widen the interval and hold the shared
+      // schedule until the retry window passes, so every request backs off together rather than only
+      // the one that was rejected.
+      this.requestIntervalMs = Math.min(
+        this.requestIntervalMs * FD_RATE_LIMIT_BACKOFF_FACTOR,
+        FD_MAX_REQUEST_INTERVAL_MS,
+      )
+      this.pauseUntil = Math.max(this.pauseUntil, Date.now() + requested)
+      console.warn(
+        `Freshdesk rate limited (429); waiting ~${Math.round(requested)}ms then retrying ` +
+          `(attempt ${attempt}/${FD_MAX_RATE_LIMIT_ATTEMPTS}, pace now ${Math.round(this.requestIntervalMs)}ms).`,
+      )
+    }
   }
 
   /**
@@ -217,13 +405,13 @@ export class FreshdeskApi {
   }
 
   async listCategories(): Promise<FreshdeskCategory[]> {
-    const res = await fetch(`${this.baseUrl}/api/v2/solutions/categories`, { headers: this.defaultHeaders })
+    const res = await this.request(`${this.baseUrl}/api/v2/solutions/categories`, { headers: this.defaultHeaders })
     await this.checkStatus(res)
     return (await res.json()) as FreshdeskCategory[]
   }
 
   async listFolders(category: FreshdeskCategory): Promise<FreshdeskFolder[]> {
-    const res = await fetch(`${this.baseUrl}/api/v2/solutions/categories/${category.id}/folders`, {
+    const res = await this.request(`${this.baseUrl}/api/v2/solutions/categories/${category.id}/folders`, {
       headers: this.defaultHeaders,
     })
     await this.checkStatus(res)
@@ -231,7 +419,7 @@ export class FreshdeskApi {
   }
 
   async listArticles(folder: FreshdeskFolder) {
-    const res = await fetch(`${this.baseUrl}/api/v2/solutions/folders/${folder.id}/articles`, {
+    const res = await this.request(`${this.baseUrl}/api/v2/solutions/folders/${folder.id}/articles`, {
       headers: this.defaultHeaders,
     })
     await this.checkStatus(res)
@@ -245,7 +433,7 @@ export class FreshdeskApi {
    * @returns the agent's id and contact details
    */
   async getAuthenticatedAgent(): Promise<FreshdeskAgent> {
-    const res = await fetch(`${this.baseUrl}/api/v2/agents/me`, { headers: this.defaultHeaders })
+    const res = await this.request(`${this.baseUrl}/api/v2/agents/me`, { headers: this.defaultHeaders })
     await this.checkStatus(res)
     return (await res.json()) as FreshdeskAgent
   }
@@ -254,13 +442,9 @@ export class FreshdeskApi {
     id: FreshdeskCategory['id'],
     locale: string,
     body: FreshdeskCategoryCreate,
-  ): Promise<FreshdeskCategory | -1> {
-    if (this.rateLimited) {
-      process.stdout.write(`Rate limited, skipping id: ${id} for ${locale}\n`)
-      return -1
-    }
+  ): Promise<FreshdeskCategory> {
     try {
-      const res = await fetch(`${this.baseUrl}/api/v2/solutions/categories/${id}/${locale}`, {
+      const res = await this.request(`${this.baseUrl}/api/v2/solutions/categories/${id}/${locale}`, {
         method: 'put',
         body: JSON.stringify(body),
         headers: this.defaultHeaders,
@@ -271,16 +455,13 @@ export class FreshdeskApi {
       const httpError = err as HttpError
       if (httpError.code === 404) {
         // not found, try create instead
-        const res2 = await fetch(`${this.baseUrl}/api/v2/solutions/categories/${id}/${locale}`, {
+        const res2 = await this.request(`${this.baseUrl}/api/v2/solutions/categories/${id}/${locale}`, {
           method: 'post',
           body: JSON.stringify(body),
           headers: this.defaultHeaders,
         })
         await this.checkStatus(res2)
         return (await res2.json()) as FreshdeskCategory
-      }
-      if (httpError.code === 429) {
-        this.rateLimited = true
       }
       process.stdout.write(`Error processing id ${id} for locale ${locale}: ${httpError.message}\n`)
       throw err
@@ -291,13 +472,9 @@ export class FreshdeskApi {
     id: FreshdeskFolder['id'],
     locale: string,
     body: FreshdeskFolderCreate,
-  ): Promise<FreshdeskFolder | -1> {
-    if (this.rateLimited) {
-      process.stdout.write(`Rate limited, skipping id: ${id} for ${locale}\n`)
-      return -1
-    }
+  ): Promise<FreshdeskFolder> {
     try {
-      const res = await fetch(`${this.baseUrl}/api/v2/solutions/folders/${id}/${locale}`, {
+      const res = await this.request(`${this.baseUrl}/api/v2/solutions/folders/${id}/${locale}`, {
         method: 'put',
         body: JSON.stringify(body),
         headers: this.defaultHeaders,
@@ -308,16 +485,13 @@ export class FreshdeskApi {
       const httpError = err as HttpError
       if (httpError.code === 404) {
         // not found, try create instead
-        const res2 = await fetch(`${this.baseUrl}/api/v2/solutions/folders/${id}/${locale}`, {
+        const res2 = await this.request(`${this.baseUrl}/api/v2/solutions/folders/${id}/${locale}`, {
           method: 'post',
           body: JSON.stringify(body),
           headers: this.defaultHeaders,
         })
         await this.checkStatus(res2)
         return (await res2.json()) as FreshdeskFolder
-      }
-      if (httpError.code === 429) {
-        this.rateLimited = true
       }
       process.stdout.write(`Error processing id ${id} for locale ${locale}: ${httpError.message}\n`)
       throw err
@@ -328,13 +502,9 @@ export class FreshdeskApi {
     id: FreshdeskArticle['id'],
     locale: string,
     body: FreshdeskArticleCreate,
-  ): Promise<FreshdeskArticle | -1> {
-    if (this.rateLimited) {
-      process.stdout.write(`Rate limited, skipping id: ${id} for ${locale}\n`)
-      return -1
-    }
+  ): Promise<FreshdeskArticle> {
     try {
-      const res = await fetch(`${this.baseUrl}/api/v2/solutions/articles/${id}/${locale}`, {
+      const res = await this.request(`${this.baseUrl}/api/v2/solutions/articles/${id}/${locale}`, {
         method: 'put',
         body: JSON.stringify(body),
         headers: this.defaultHeaders,
@@ -345,16 +515,13 @@ export class FreshdeskApi {
       const httpError = err as HttpError
       if (httpError.code === 404) {
         // not found, try create instead
-        const res2 = await fetch(`${this.baseUrl}/api/v2/solutions/articles/${id}/${locale}`, {
+        const res2 = await this.request(`${this.baseUrl}/api/v2/solutions/articles/${id}/${locale}`, {
           method: 'post',
           body: JSON.stringify(body),
           headers: this.defaultHeaders,
         })
         await this.checkStatus(res2)
         return (await res2.json()) as FreshdeskArticle
-      }
-      if (httpError.code === 429) {
-        this.rateLimited = true
       }
       process.stdout.write(`Error processing id ${id} for locale ${locale}: ${httpError.message}\n`)
       throw err

--- a/scripts/lib/help-utils.mts
+++ b/scripts/lib/help-utils.mts
@@ -19,6 +19,34 @@ import { emitWarning } from './warnings.mts'
 const FD = new FreshdeskApi('https://mitscratch.freshdesk.com', process.env.FRESHDESK_TOKEN ?? '')
 const TX_PROJECT = 'scratch-help'
 
+// Collect per-item failures instead of aborting on the first one, so one bad translation or a single
+// item the token cannot write still lets every other item sync. Freshdesk rate limiting is handled
+// transparently by the client (paced requests, `Retry-After`-aware retries), so anything that reaches
+// here is a genuine problem worth a human's attention. `reportFailures` prints a consolidated summary
+// and fails the run at the end, so real errors are surfaced rather than lost in the log.
+const failures: { context: string; message: string }[] = []
+const recordFailure = (context: string, error: unknown): void => {
+  const message = messageOf(error)
+  // Genuine failures go to stderr (like the consolidated summary), so they stand apart from normal output.
+  process.stderr.write(`Error: ${context}: ${message}\n`)
+  failures.push({ context, message })
+}
+
+/**
+ * Print a summary of everything that failed during the sync and mark the process as failed if there
+ * was anything. Call once, after all saves have completed.
+ */
+export const reportFailures = (): void => {
+  if (failures.length === 0) {
+    return
+  }
+  console.error(`\n${failures.length} item(s) failed to sync to Freshdesk:`)
+  for (const failure of failures) {
+    console.error(`  - ${failure.context}: ${failure.message}`)
+  }
+  process.exitCode = 1
+}
+
 /**
  * Log which agent the configured Freshdesk token authenticates as, to aid in diagnosing permission
  * problems. Never throws.
@@ -141,27 +169,20 @@ const serializeNameSave = async (
         }
         continue
       }
-      let status
       if (resource.attributes.name === 'categoryNames_json') {
-        status = await FD.updateCategoryTranslation(id, freshdeskLocale(locale), { name: value })
+        await FD.updateCategoryTranslation(id, freshdeskLocale(locale), { name: value })
       } else if (resource.attributes.name === 'folderNames_json') {
-        status = await FD.updateFolderTranslation(id, freshdeskLocale(locale), { name: value })
+        await FD.updateFolderTranslation(id, freshdeskLocale(locale), { name: value })
       } else {
         // Guard against silently dropping an unexpected resource: this function only knows how to
         // write category and folder names. A new KEYVALUEJSON names resource would otherwise no-op
         // while still reporting success.
         throw new Error(`Unexpected names resource "${resource.attributes.name}"; don't know how to save it`)
       }
-      if (status === -1) {
-        process.exitCode = 1
-      }
     } catch (error) {
-      // The FreshdeskApi update method already logged the specific error. Record the failure so the
-      // job still exits non-zero, then move on to the next entry.
-      process.stdout.write(
-        `Failed to save an entry in ${resource.attributes.name} for ${locale} (key "${key}"): ${messageOf(error)}\n`,
-      )
-      process.exitCode = 1
+      // Record the failure so the job still reports a non-zero exit at the end, then move on to the
+      // next entry.
+      recordFailure(`${resource.attributes.name} entry "${key}" for ${locale}`, error)
     }
   }
 }
@@ -207,15 +228,11 @@ const serializeFolderSave = async (json: TransifexStrings<FreshdeskFolderInTrans
         }
         body.tags = validTags
       }
-      const status = await FD.updateArticleTranslation(id, freshdeskLocale(locale), body)
-      if (status === -1) {
-        process.exitCode = 1
-      }
+      await FD.updateArticleTranslation(id, freshdeskLocale(locale), body)
     } catch (error) {
-      // The FreshdeskApi update method already logged the specific error. Record the failure so the
-      // job still exits non-zero, then move on to the next article.
-      process.stdout.write(`Failed to save article ${idString} for ${locale}: ${messageOf(error)}\n`)
-      process.exitCode = 1
+      // Record the failure so the job still reports a non-zero exit at the end, then move on to the
+      // next article.
+      recordFailure(`article ${idString} for ${locale}`, error)
     }
   }
 }
@@ -235,8 +252,7 @@ export const localizeFolder = async (folderAttributes: TransifexResourceObject, 
     )
     await serializeFolderSave(data, locale)
   } catch (e) {
-    process.stdout.write(`Error processing ${folderAttributes.attributes.slug}, ${locale}: ${(e as Error).message}\n`)
-    process.exitCode = 1 // not ok
+    recordFailure(`${folderAttributes.attributes.slug} for ${locale}`, e)
   }
 }
 
@@ -281,10 +297,7 @@ export const localizeNames = async (
   const validIds = resource.attributes.name === 'categoryNames_json' ? validCategoryIds : validFolderIds
   await txPull<TransifexStringKeyValueJson>(TX_PROJECT, resource.attributes.slug, locale, 'default')
     .then(data => serializeNameSave(data, resource, locale, validIds, warnedKeys))
-    .catch(e => {
-      process.stdout.write(`Error saving ${resource.attributes.slug}, ${locale}: ${(e as Error).message}\n`)
-      process.exitCode = 1 // not ok
-    })
+    .catch(e => recordFailure(`${resource.attributes.slug} for ${locale}`, e))
 }
 
 const BATCH_SIZE = 2
@@ -300,9 +313,8 @@ type SaveFn = (item: TransifexResourceObject, language: string) => Promise<void>
 export const saveItem = async (item: TransifexResourceObject, languages: string[], saveFn: SaveFn) => {
   const saveLanguages = languages.filter(l => l !== 'en') // exclude English from update
   for (let i = 0; i < saveLanguages.length; i += BATCH_SIZE) {
-    await Promise.all(saveLanguages.slice(i, i + BATCH_SIZE).map(l => saveFn(item, l))).catch(err => {
-      process.stdout.write(`Error saving item:${(err as Error).message}\n${JSON.stringify(item, null, 2)}\n`)
-      process.exitCode = 1 // not ok
-    })
+    await Promise.all(saveLanguages.slice(i, i + BATCH_SIZE).map(l => saveFn(item, l))).catch(err =>
+      recordFailure(`saving ${item.attributes.slug}`, err),
+    )
   }
 }

--- a/scripts/tx-pull-help-articles.mts
+++ b/scripts/tx-pull-help-articles.mts
@@ -3,7 +3,7 @@
  * @file
  * Script to pull scratch-help translations from transifex and push to FreshDesk.
  */
-import { getInputs, saveItem, localizeFolder } from './lib/help-utils.mts'
+import { getInputs, saveItem, localizeFolder, reportFailures } from './lib/help-utils.mts'
 
 const args = process.argv.slice(2)
 const usage = `
@@ -24,3 +24,4 @@ if (!process.env.TX_TOKEN || !process.env.FRESHDESK_TOKEN || args.length > 0) {
 const { languages, folders } = await getInputs()
 console.log('Processing articles pulled from Transifex')
 await Promise.all(folders.map(item => saveItem(item, languages, localizeFolder)))
+reportFailures()

--- a/scripts/tx-pull-help-names.mts
+++ b/scripts/tx-pull-help-names.mts
@@ -3,7 +3,14 @@
  * @file
  * Script to pull scratch-help translations from transifex and push to FreshDesk.
  */
-import { getInputs, getValidFreshdeskIds, saveItem, localizeNames, logFreshdeskAgent } from './lib/help-utils.mts'
+import {
+  getInputs,
+  getValidFreshdeskIds,
+  saveItem,
+  localizeNames,
+  logFreshdeskAgent,
+  reportFailures,
+} from './lib/help-utils.mts'
 
 const args = process.argv.slice(2)
 
@@ -37,3 +44,4 @@ await Promise.all(
     ),
   ),
 )
+reportFailures()


### PR DESCRIPTION
### Proposed Changes

Pace Freshdesk writes to the rate limit the server advertises instead of firing
them as fast as possible and treating a 429 as a hard stop.

- Serialize requests through a paced queue whose interval is derived at send time
  from Freshdesk's `X-RateLimit-Total`/`-Remaining` headers, targeting ~75% of the
  advertised budget and pausing briefly when the remaining budget runs low.
- On a 429, honor `Retry-After` (capped at two minutes) rather than latching the
  whole run into a permanently rate-limited state.
- Remove the old permanent `rateLimited` latch and its `-1` "skipped" return, which
  silently dropped every write after the first 429 and masked real per-item errors.
- Collect per-item failures and print a consolidated summary that fails the run at
  the end, and emit the rate-limit notice once per run instead of per request.

Note: this makes the writes well-behaved but does not by itself reduce their
volume, so a full run can still exceed the workflow timeout. The follow-up
change-detection work (which builds on this branch) is what brings a normal run
down to only what changed.
