### PR TITLE
Sync only changed help translations

### DIFF
--- a/.github/workflows/daily-help-update.yml
+++ b/.github/workflows/daily-help-update.yml
@@ -2,6 +2,11 @@ name: Daily Help Update
 
 on:
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+    inputs:
+      dry_run:
+        description: 'Dry run: pull and report what would sync to Freshdesk, without writing'
+        type: boolean
+        default: false
   schedule:
     # daily-help-update (e.g., daily at 5 AM UTC)
     - cron: '0 5 * * *'
@@ -19,8 +24,10 @@ permissions:
 jobs:
   daily-help-update:
     runs-on: ubuntu-latest
-    # Backstop only: the sync should finish in a few minutes. The Transifex client code bounds its
-    # own waits, so this guards against an unexpected hang rather than being the primary timeout.
+    # Hard backstop against an unexpected hang. The sync stops issuing new writes at its own softer
+    # wall-clock budget (HELP_SYNC_MAX_MINUTES, default 24) and exits cleanly under this limit, so the
+    # cache save below always runs and partial progress from a first-time full sync is never lost to a
+    # cancellation.
     timeout-minutes: 30
 
     steps:
@@ -35,13 +42,37 @@ jobs:
           npm ci
           npx browserslist@latest --update-db
 
+      # The change-detection baseline records the last-synced Transifex timestamp per (resource, locale)
+      # so each run only pushes what changed. It is not committed; it lives in the cache. The key is
+      # unique per run attempt (run_id + run_attempt, since a re-run keeps the same run_id) so the
+      # post-job save always stores that attempt's updated baseline, and restore-keys pulls the most
+      # recent prior baseline. If the cache is ever evicted, the baseline is simply rebuilt by a
+      # one-time full sync (which converges over a few runs).
+      - name: Restore and save the help-sync baseline
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: scripts/help-sync-baseline.json
+          key: help-sync-baseline-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            help-sync-baseline-
+
       - name: Sync help
         env:
           # Organization-wide secrets
           FRESHDESK_TOKEN: ${{ secrets.FRESHDESK_TOKEN }}
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
           WARNINGS_FILE: ${{ runner.temp }}/sync-help-warnings.txt
-        run: npm run sync:help
+          # Empty except on a manual dry-run dispatch, where it makes the pull report what it would
+          # write to Freshdesk without issuing any writes. Read through github.event.inputs (rather than
+          # the inputs context) so scheduled runs, which have no inputs, safely resolve to "not dry-run".
+          DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '' }}
+        run: |
+          if [ -n "$DRY_RUN" ]; then
+            echo "DRY RUN: pulling and reporting what would sync, without writing to Freshdesk."
+            npm run pull:help
+          else
+            npm run sync:help
+          fi
 
       - name: Check for warnings
         id: check-warnings

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ npm-*
 
 # generated build files
 /dist
+
+# help-sync change-detection baseline (restored from and saved to CI cache, not committed)
+/scripts/help-sync-baseline.json

--- a/scripts/lib/freshdesk-api.mts
+++ b/scripts/lib/freshdesk-api.mts
@@ -165,6 +165,20 @@ export interface FreshdeskAgent {
   }
 }
 
+/**
+ * Helpdesk settings, as returned by `GET /api/v2/settings/helpdesk`. These determine which languages
+ * the knowledge base can hold translations in, so they gate which locales we can push.
+ * @see https://developers.freshdesk.com/api/#settings
+ */
+export interface FreshdeskHelpdeskSettings {
+  /** The account's primary language code; its content lives on the base resource, not a translation. */
+  primary_language?: string
+  /** Language codes translations may be created for (configured in Admin > Helpdesk Settings). */
+  supported_languages?: string[]
+  /** Subset of supported languages exposed on the support portal. */
+  portal_languages?: string[]
+}
+
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
 /** Interval used before the server has told us its limit, in ms (conservative, avoids an opening burst). */
@@ -438,94 +452,91 @@ export class FreshdeskApi {
     return (await res.json()) as FreshdeskAgent
   }
 
-  async updateCategoryTranslation(
-    id: FreshdeskCategory['id'],
+  /**
+   * Fetch the account's helpdesk settings, including the primary language and the set of supported
+   * languages that gate which locales the knowledge base can hold translations for.
+   * @returns the primary language, supported languages, and portal languages
+   */
+  async getHelpdeskSettings(): Promise<FreshdeskHelpdeskSettings> {
+    const res = await this.request(`${this.baseUrl}/api/v2/settings/helpdesk`, { headers: this.defaultHeaders })
+    await this.checkStatus(res)
+    return (await res.json()) as FreshdeskHelpdeskSettings
+  }
+
+  /**
+   * Send a translation write and confirm it succeeded, then drain the response body so undici can
+   * release (and reuse) the connection promptly. A large sync issues thousands of writes and we do
+   * not use the returned translation object, so an undrained body would keep connections busy.
+   * @param url - the translation endpoint
+   * @param method - `put` to update, or `post` to create
+   * @param payload - the serialized translation body
+   */
+  private async writeRequest(url: string, method: 'put' | 'post', payload: string): Promise<void> {
+    const res = await this.request(url, { method, body: payload, headers: this.defaultHeaders })
+    await this.checkStatus(res)
+    await res.text().catch(() => undefined)
+  }
+
+  /**
+   * Write one translation with an optimistic update-then-create flow: `PUT` assuming it exists and,
+   * only on a 404, `POST` to create it. If the create is refused because the translation already
+   * exists (`409 duplicate_value`, or `405` where the endpoint only allows GET/PUT), Freshdesk is
+   * telling us the record exists even though `PUT` reported 404 — a state we cannot resolve through
+   * the API (typically an unsupported or primary language). Rather than fail the whole run, surface
+   * it as a warning and move on. Any other error is re-thrown for the caller to record.
+   * @param resourcePath - the solutions sub-path: `categories`, `folders`, or `articles`
+   * @param id - the primary resource id the translation belongs to
+   * @param locale - the Freshdesk language code
+   * @param body - the translation payload
+   * @returns true if the translation was written; false if Freshdesk reported it as an unresolvable
+   * already-exists skip, so callers can avoid advancing their synced baseline for a pair not written
+   */
+  private async writeTranslation(
+    resourcePath: 'categories' | 'folders' | 'articles',
+    id: number,
     locale: string,
-    body: FreshdeskCategoryCreate,
-  ): Promise<FreshdeskCategory> {
+    body: FreshdeskCategoryCreate | FreshdeskFolderCreate | FreshdeskArticleCreate,
+  ): Promise<boolean> {
+    const url = `${this.baseUrl}/api/v2/solutions/${resourcePath}/${id}/${locale}`
+    const payload = JSON.stringify(body)
     try {
-      const res = await this.request(`${this.baseUrl}/api/v2/solutions/categories/${id}/${locale}`, {
-        method: 'put',
-        body: JSON.stringify(body),
-        headers: this.defaultHeaders,
-      })
-      await this.checkStatus(res)
-      return (await res.json()) as FreshdeskCategory
+      await this.writeRequest(url, 'put', payload)
+      return true
     } catch (err) {
-      const httpError = err as HttpError
-      if (httpError.code === 404) {
-        // not found, try create instead
-        const res2 = await this.request(`${this.baseUrl}/api/v2/solutions/categories/${id}/${locale}`, {
-          method: 'post',
-          body: JSON.stringify(body),
-          headers: this.defaultHeaders,
-        })
-        await this.checkStatus(res2)
-        return (await res2.json()) as FreshdeskCategory
+      if ((err as HttpError).code !== 404) {
+        process.stdout.write(`Error processing id ${id} for locale ${locale}: ${(err as HttpError).message}\n`)
+        throw err
       }
-      process.stdout.write(`Error processing id ${id} for locale ${locale}: ${httpError.message}\n`)
+      // PUT 404: the translation does not exist yet, so fall through and create it.
+    }
+    try {
+      await this.writeRequest(url, 'post', payload)
+      return true
+    } catch (err) {
+      const code = (err as HttpError).code
+      if (code === 409 || code === 405) {
+        emitWarning(
+          `Skipping ${resourcePath} ${id} translation for "${locale}": Freshdesk refused the create ` +
+            `(HTTP ${code}) after PUT returned 404. This usually means "${locale}" is the primary ` +
+            `language or is not enabled in Freshdesk; enable it there to sync it.`,
+        )
+        return false
+      }
+      process.stdout.write(`Error processing id ${id} for locale ${locale}: ${(err as HttpError).message}\n`)
       throw err
     }
   }
 
-  async updateFolderTranslation(
-    id: FreshdeskFolder['id'],
-    locale: string,
-    body: FreshdeskFolderCreate,
-  ): Promise<FreshdeskFolder> {
-    try {
-      const res = await this.request(`${this.baseUrl}/api/v2/solutions/folders/${id}/${locale}`, {
-        method: 'put',
-        body: JSON.stringify(body),
-        headers: this.defaultHeaders,
-      })
-      await this.checkStatus(res)
-      return (await res.json()) as FreshdeskFolder
-    } catch (err) {
-      const httpError = err as HttpError
-      if (httpError.code === 404) {
-        // not found, try create instead
-        const res2 = await this.request(`${this.baseUrl}/api/v2/solutions/folders/${id}/${locale}`, {
-          method: 'post',
-          body: JSON.stringify(body),
-          headers: this.defaultHeaders,
-        })
-        await this.checkStatus(res2)
-        return (await res2.json()) as FreshdeskFolder
-      }
-      process.stdout.write(`Error processing id ${id} for locale ${locale}: ${httpError.message}\n`)
-      throw err
-    }
+  async updateCategoryTranslation(id: number, locale: string, body: FreshdeskCategoryCreate): Promise<boolean> {
+    return this.writeTranslation('categories', id, locale, body)
   }
 
-  async updateArticleTranslation(
-    id: FreshdeskArticle['id'],
-    locale: string,
-    body: FreshdeskArticleCreate,
-  ): Promise<FreshdeskArticle> {
-    try {
-      const res = await this.request(`${this.baseUrl}/api/v2/solutions/articles/${id}/${locale}`, {
-        method: 'put',
-        body: JSON.stringify(body),
-        headers: this.defaultHeaders,
-      })
-      await this.checkStatus(res)
-      return (await res.json()) as FreshdeskArticle
-    } catch (err) {
-      const httpError = err as HttpError
-      if (httpError.code === 404) {
-        // not found, try create instead
-        const res2 = await this.request(`${this.baseUrl}/api/v2/solutions/articles/${id}/${locale}`, {
-          method: 'post',
-          body: JSON.stringify(body),
-          headers: this.defaultHeaders,
-        })
-        await this.checkStatus(res2)
-        return (await res2.json()) as FreshdeskArticle
-      }
-      process.stdout.write(`Error processing id ${id} for locale ${locale}: ${httpError.message}\n`)
-      throw err
-    }
+  async updateFolderTranslation(id: number, locale: string, body: FreshdeskFolderCreate): Promise<boolean> {
+    return this.writeTranslation('folders', id, locale, body)
+  }
+
+  async updateArticleTranslation(id: number, locale: string, body: FreshdeskArticleCreate): Promise<boolean> {
+    return this.writeTranslation('articles', id, locale, body)
   }
 }
 

--- a/scripts/lib/help-utils.mts
+++ b/scripts/lib/help-utils.mts
@@ -11,9 +11,10 @@ import FreshdeskApi, {
   FreshdeskFolder,
   logAuthenticatedAgent,
 } from './freshdesk-api.mts'
+import { loadBaseline, saveBaseline, SyncBaseline } from './sync-baseline.mts'
 import { TransifexStringKeyValueJson, TransifexStringsKeyValueJson, TransifexStrings } from './transifex-formats.mts'
 import { TransifexResourceObject } from './transifex-objects.mts'
-import { txPull, txResourcesObjects, txAvailableLanguages } from './transifex.mts'
+import { txPull, txResourcesObjects, txAvailableLanguages, txResourceLanguageStats } from './transifex.mts'
 import { emitWarning } from './warnings.mts'
 
 const FD = new FreshdeskApi('https://mitscratch.freshdesk.com', process.env.FRESHDESK_TOKEN ?? '')
@@ -45,6 +46,178 @@ export const reportFailures = (): void => {
     console.error(`  - ${failure.context}: ${failure.message}`)
   }
   process.exitCode = 1
+}
+
+// --- Change detection -------------------------------------------------------
+// The sync used to push every translation for every locale on every run (~10k+ Freshdesk writes),
+// which is what tripped the rate limit. We now pull per-(resource, locale) stats from Transifex once
+// and skip any pair whose translations have not changed since the last successful sync, so a normal
+// day writes only what actually moved. `DRY_RUN` does everything except issue the Freshdesk writes,
+// for validating the gate without mutating the knowledge base.
+
+/** When set (to a non-empty value other than "0"/"false"), do everything except issue Freshdesk writes. */
+const DRY_RUN = !!process.env.DRY_RUN && process.env.DRY_RUN !== '0' && process.env.DRY_RUN.toLowerCase() !== 'false'
+
+/**
+ * Wall-clock budget for a single run, in minutes (override with `HELP_SYNC_MAX_MINUTES`). When it is
+ * exceeded the sync stops starting new writes, persists the baseline for everything that finished, and
+ * exits cleanly. This matters because the baseline is restored from and saved to a CI cache whose save
+ * step only runs when the job is not cancelled: finishing under the job's hard `timeout-minutes` keeps
+ * partial progress, so a first-time full sync that cannot complete in one run converges over several
+ * daily runs instead of losing everything to a timeout.
+ */
+const RUN_TIME_BUDGET_MS = (() => {
+  const minutes = Number(process.env.HELP_SYNC_MAX_MINUTES)
+  return (Number.isFinite(minutes) && minutes > 0 ? minutes : 24) * 60_000
+})()
+/** When this run began, used to enforce {@link RUN_TIME_BUDGET_MS}. */
+const runStartedAt = Date.now()
+/** Count of changed, supported pairs left unattempted because the run hit its time budget. */
+let deferredForBudget = 0
+
+/**
+ * Whether the run has used up its wall-clock budget and should stop starting new writes. Only active
+ * once change detection is initialized, so the locale-debug script (which force-pulls) is unaffected.
+ * @returns true if no further writes should be started this run
+ */
+const runBudgetExhausted = (): boolean => changeDetectionReady && Date.now() - runStartedAt >= RUN_TIME_BUDGET_MS
+
+/** Whether {@link initChangeDetection} has run; until it has, the gate is disabled (sync everything). */
+let changeDetectionReady = false
+/** Transifex last-update timestamp per `<resourceSlug>:<localeCode>`, loaded once per run. */
+let currentStats = new Map<string, string | null>()
+/** The baseline recorded by the previous successful sync, loaded once per run. */
+let baseline: SyncBaseline = new Map()
+/** Pairs synced this run (or, in a dry run, that would sync), folded into the baseline at the end. */
+const syncedPairs: SyncBaseline = new Map()
+/** Count of Freshdesk writes skipped in a dry run, reported at the end. */
+let plannedWrites = 0
+
+/** Whether the Freshdesk supported-language filter is active (helpdesk settings loaded successfully). */
+let localeFilterActive = false
+/** Freshdesk supported language codes (lowercased) the knowledge base can hold translations for. */
+const supportedFreshdeskLocales = new Set<string>()
+/** Freshdesk primary language (lowercased); its content lives on the base resource, not a translation. */
+let primaryLanguage = ''
+
+/**
+ * Load the Transifex per-(resource, locale) stats, the previous baseline, and the Freshdesk helpdesk
+ * settings (which languages the KB can hold translations for). Call once before syncing.
+ * @returns a promise that resolves once change-detection state is loaded
+ */
+export const initChangeDetection = async (): Promise<void> => {
+  currentStats = await txResourceLanguageStats(TX_PROJECT)
+  baseline = loadBaseline()
+  try {
+    const settings = await FD.getHelpdeskSettings()
+    primaryLanguage = (settings.primary_language ?? '').toLowerCase()
+    for (const code of settings.supported_languages ?? []) {
+      supportedFreshdeskLocales.add(code.toLowerCase())
+    }
+    localeFilterActive = supportedFreshdeskLocales.size > 0
+  } catch (error) {
+    // If the settings can't be read, don't gate on language: attempt every locale and let the
+    // create path warn about any Freshdesk won't accept.
+    console.warn(`Could not read Freshdesk helpdesk settings; not filtering locales: ${messageOf(error)}`)
+  }
+  changeDetectionReady = true
+}
+
+/**
+ * Whether Freshdesk can hold a translation for a Transifex locale: it must map to a configured
+ * supported language and not be the primary language (whose content lives on the base resource).
+ * @param locale - the Transifex locale code
+ * @returns true if the locale should be pushed to Freshdesk
+ */
+const localeSupported = (locale: string): boolean => {
+  // Until the filter is active (settings not loaded, or the locale-debug script), don't gate.
+  if (!localeFilterActive) {
+    return true
+  }
+  const fd = freshdeskLocale(locale).toLowerCase()
+  return fd !== primaryLanguage && supportedFreshdeskLocales.has(fd)
+}
+
+/**
+ * Emit a single warning naming the locales Freshdesk is not configured to hold translations for, so
+ * someone reading the logs can decide whether to enable any of them in Freshdesk.
+ * @param languages - the Transifex locales the sync would otherwise push
+ */
+export const reportSkippedLocales = (languages: string[]): void => {
+  if (!localeFilterActive) {
+    return
+  }
+  // Report the Freshdesk language codes (deduplicated: several Transifex locales can map to one),
+  // because those are what an operator enables in Freshdesk -- not the raw Transifex locale codes.
+  const skipped = [...new Set(languages.filter(l => l !== 'en' && !localeSupported(l)).map(freshdeskLocale))].sort()
+  if (skipped.length > 0) {
+    emitWarning(
+      `Skipping ${skipped.length} Freshdesk language(s) not enabled for the knowledge base; their ` +
+        `translations cannot sync until they are added under Admin > Helpdesk Settings: ${skipped.join(', ')}.`,
+    )
+  }
+}
+
+/**
+ * Whether a (resource, locale) pair has translations worth pushing: it must have translated content
+ * and a newer last-update timestamp than the baseline recorded.
+ * @param resource - the Transifex resource slug
+ * @param locale - the Transifex locale code
+ * @returns true if the pair changed since the last successful sync
+ */
+const pairChanged = (resource: string, locale: string): boolean => {
+  // When change detection hasn't been initialized (for example the locale-debug script, which
+  // deliberately force-pulls), don't gate — behave as before and sync everything requested.
+  if (!changeDetectionReady) {
+    return true
+  }
+  const current = currentStats.get(`${resource}:${locale}`)
+  // No stats for the pair, or nothing translated yet -> nothing to push.
+  if (!current) {
+    return false
+  }
+  return baseline.get(`${resource}:${locale}`) !== current
+}
+
+/**
+ * Record that a (resource, locale) pair synced successfully, so its baseline entry advances to the
+ * current Transifex timestamp when the run finishes.
+ * @param resource - the Transifex resource slug
+ * @param locale - the Transifex locale code
+ */
+const markSynced = (resource: string, locale: string): void => {
+  const current = currentStats.get(`${resource}:${locale}`)
+  if (current) {
+    syncedPairs.set(`${resource}:${locale}`, current)
+  }
+}
+
+/**
+ * Finish the run: persist the advanced baseline (unless this is a dry run) and print the failure
+ * summary. Call once, after all saves have completed.
+ */
+export const finalizeSync = (): void => {
+  if (DRY_RUN) {
+    console.log(
+      `[dry-run] ${syncedPairs.size} (resource, locale) pair(s) changed and would sync, for ` +
+        `${plannedWrites} Freshdesk write(s). No writes were issued and the baseline was left unchanged.`,
+    )
+  } else {
+    for (const [key, timestamp] of syncedPairs) {
+      baseline.set(key, timestamp)
+    }
+    saveBaseline(baseline)
+    console.log(`Synced ${syncedPairs.size} (resource, locale) pair(s); baseline now holds ${baseline.size} entries.`)
+  }
+  if (deferredForBudget > 0) {
+    // Informational, not a warning: during a first-time full sync this is expected every run until the
+    // backlog clears, and routing it through emitWarning would alert on every one of those runs.
+    console.log(
+      `Reached the ${RUN_TIME_BUDGET_MS / 60_000}-minute run budget with ${deferredForBudget} changed ` +
+        `pair(s) not yet synced; they will sync on subsequent runs as the baseline converges.`,
+    )
+  }
+  reportFailures()
 }
 
 /**
@@ -144,6 +317,7 @@ export const getValidFreshdeskIds = async () => {
  * @param locale - the Transifex locale code corresponding to these strings
  * @param validIds - set of Freshdesk IDs that currently exist; keys not in this set are skipped
  * @param warnedKeys - tracks which stale resource+ID combinations have already been reported, to avoid repeating the warning
+ * @returns true if every entry saved without a failure (stale-key skips do not count as failures)
  */
 const serializeNameSave = async (
   strings: TransifexStringsKeyValueJson,
@@ -151,7 +325,8 @@ const serializeNameSave = async (
   locale: string,
   validIds: Set<number>,
   warnedKeys: Set<string>,
-): Promise<void> => {
+): Promise<boolean> => {
+  let allOk = true
   for (const [key, value] of Object.entries(strings)) {
     // Handle each entry independently: a failure on one item (for example a translation the token
     // is not allowed to write) must not abort the remaining names for this locale.
@@ -169,22 +344,30 @@ const serializeNameSave = async (
         }
         continue
       }
-      if (resource.attributes.name === 'categoryNames_json') {
-        await FD.updateCategoryTranslation(id, freshdeskLocale(locale), { name: value })
-      } else if (resource.attributes.name === 'folderNames_json') {
-        await FD.updateFolderTranslation(id, freshdeskLocale(locale), { name: value })
-      } else {
-        // Guard against silently dropping an unexpected resource: this function only knows how to
-        // write category and folder names. A new KEYVALUEJSON names resource would otherwise no-op
-        // while still reporting success.
+      // Guard against silently dropping an unexpected resource: this function only knows how to write
+      // category and folder names. A new KEYVALUEJSON names resource would otherwise no-op while
+      // still reporting success.
+      if (resource.attributes.name !== 'categoryNames_json' && resource.attributes.name !== 'folderNames_json') {
         throw new Error(`Unexpected names resource "${resource.attributes.name}"; don't know how to save it`)
+      }
+      if (DRY_RUN) {
+        plannedWrites++
+      } else if (resource.attributes.name === 'categoryNames_json') {
+        // A skipped write (Freshdesk reports it already exists) must not advance the baseline.
+        if (!(await FD.updateCategoryTranslation(id, freshdeskLocale(locale), { name: value }))) {
+          allOk = false
+        }
+      } else if (!(await FD.updateFolderTranslation(id, freshdeskLocale(locale), { name: value }))) {
+        allOk = false
       }
     } catch (error) {
       // Record the failure so the job still reports a non-zero exit at the end, then move on to the
       // next entry.
       recordFailure(`${resource.attributes.name} entry "${key}" for ${locale}`, error)
+      allOk = false
     }
   }
+  return allOk
 }
 
 /**
@@ -201,9 +384,13 @@ interface FreshdeskFolderInTransifex {
  * Internal function serialize Freshdesk requests to avoid getting rate limited
  * @param  json   object with keys corresponding to article ids
  * @param  locale language code
- * @returns a numeric status code
+ * @returns true if every article saved without a failure
  */
-const serializeFolderSave = async (json: TransifexStrings<FreshdeskFolderInTransifex>, locale: string) => {
+const serializeFolderSave = async (
+  json: TransifexStrings<FreshdeskFolderInTransifex>,
+  locale: string,
+): Promise<boolean> => {
+  let allOk = true
   for (const [idString, value] of Object.entries(json)) {
     // Handle each article independently: a failure on one must not abort the rest for this locale.
     try {
@@ -228,21 +415,29 @@ const serializeFolderSave = async (json: TransifexStrings<FreshdeskFolderInTrans
         }
         body.tags = validTags
       }
-      await FD.updateArticleTranslation(id, freshdeskLocale(locale), body)
+      if (DRY_RUN) {
+        plannedWrites++
+      } else if (!(await FD.updateArticleTranslation(id, freshdeskLocale(locale), body))) {
+        // A skipped write (Freshdesk reports it already exists) must not advance the baseline.
+        allOk = false
+      }
     } catch (error) {
       // Record the failure so the job still reports a non-zero exit at the end, then move on to the
       // next article.
       recordFailure(`article ${idString} for ${locale}`, error)
+      allOk = false
     }
   }
+  return allOk
 }
 
 /**
  * Process Transifex resource corresponding to a Knowledge base folder on Freshdesk
  * @param  folderAttributes Transifex resource json corresponding to a KB folder
  * @param  locale locale to pull and submit to Freshdesk
+ * @returns true if the folder's articles for this locale all saved without a failure
  */
-export const localizeFolder = async (folderAttributes: TransifexResourceObject, locale: string) => {
+export const localizeFolder = async (folderAttributes: TransifexResourceObject, locale: string): Promise<boolean> => {
   try {
     const data = await txPull<FreshdeskFolderInTransifex>(
       TX_PROJECT,
@@ -250,9 +445,10 @@ export const localizeFolder = async (folderAttributes: TransifexResourceObject, 
       locale,
       'default',
     )
-    await serializeFolderSave(data, locale)
+    return await serializeFolderSave(data, locale)
   } catch (e) {
     recordFailure(`${folderAttributes.attributes.slug} for ${locale}`, e)
+    return false
   }
 }
 
@@ -260,22 +456,22 @@ export const localizeFolder = async (folderAttributes: TransifexResourceObject, 
  * Save Transifex resource corresponding to a Knowledge base folder locally for debugging
  * @param  folderAttributes Transifex resource json corresponding to a KB folder
  * @param  locale locale to pull and save
+ * @returns true if the resource was pulled and written to the debug file
  */
-export const debugFolder = async (folderAttributes: TransifexResourceObject, locale: string) => {
+export const debugFolder = async (folderAttributes: TransifexResourceObject, locale: string): Promise<boolean> => {
   await mkdirp('tmpDebug')
-  await txPull(TX_PROJECT, folderAttributes.attributes.slug, locale, 'default')
-    .then(data =>
-      fsPromises.writeFile(
-        `tmpDebug/${folderAttributes.attributes.slug}_${locale}.json`,
-        JSON.stringify(data, null, 2),
-      ),
+  try {
+    const data = await txPull(TX_PROJECT, folderAttributes.attributes.slug, locale, 'default')
+    await fsPromises.writeFile(
+      `tmpDebug/${folderAttributes.attributes.slug}_${locale}.json`,
+      JSON.stringify(data, null, 2),
     )
-    .catch(e => {
-      process.stdout.write(
-        `Error processing ${folderAttributes.attributes.slug}, ${locale}: ${(e as Error).message}\n`,
-      )
-      process.exitCode = 1 // not ok
-    })
+    return true
+  } catch (e) {
+    process.stdout.write(`Error processing ${folderAttributes.attributes.slug}, ${locale}: ${messageOf(e)}\n`)
+    process.exitCode = 1 // not ok
+    return false
+  }
 }
 
 /**
@@ -286,6 +482,7 @@ export const debugFolder = async (folderAttributes: TransifexResourceObject, loc
  * @param validCategoryIds - set of Freshdesk category IDs that currently exist
  * @param validFolderIds - set of Freshdesk folder IDs that currently exist
  * @param warnedKeys - tracks which stale resource+ID combinations have already been reported, to avoid repeating the warning
+ * @returns true if the names for this locale all saved without a failure
  */
 export const localizeNames = async (
   resource: TransifexResourceObject,
@@ -293,28 +490,52 @@ export const localizeNames = async (
   validCategoryIds: Set<number>,
   validFolderIds: Set<number>,
   warnedKeys: Set<string>,
-): Promise<void> => {
+): Promise<boolean> => {
   const validIds = resource.attributes.name === 'categoryNames_json' ? validCategoryIds : validFolderIds
-  await txPull<TransifexStringKeyValueJson>(TX_PROJECT, resource.attributes.slug, locale, 'default')
-    .then(data => serializeNameSave(data, resource, locale, validIds, warnedKeys))
-    .catch(e => recordFailure(`${resource.attributes.slug} for ${locale}`, e))
+  try {
+    const data = await txPull<TransifexStringKeyValueJson>(TX_PROJECT, resource.attributes.slug, locale, 'default')
+    return await serializeNameSave(data, resource, locale, validIds, warnedKeys)
+  } catch (e) {
+    recordFailure(`${resource.attributes.slug} for ${locale}`, e)
+    return false
+  }
 }
 
 const BATCH_SIZE = 2
 
-type SaveFn = (item: TransifexResourceObject, language: string) => Promise<void>
+type SaveFn = (item: TransifexResourceObject, language: string) => Promise<boolean>
 
 /**
- * save resource items in batches to reduce rate limiting errors
- * @param item      Transifex resource json, used for 'slug'
- * @param languages  Array of languages to save
- * @param saveFn  Async function to use to save the item
+ * Save a resource's translations in batches (to reduce rate-limit pressure), skipping any locale that
+ * has not changed since the last successful sync. A locale is recorded as synced only after its save
+ * reports success, so a partial or failed run re-syncs that pair next time instead of silently
+ * skipping it.
+ * @param item - Transifex resource object, used for its slug
+ * @param languages - array of locales to consider saving
+ * @param saveFn - async function that saves the item for one locale and returns whether it fully succeeded
+ * @returns a promise that resolves once every changed locale has been attempted
  */
-export const saveItem = async (item: TransifexResourceObject, languages: string[], saveFn: SaveFn) => {
-  const saveLanguages = languages.filter(l => l !== 'en') // exclude English from update
+export const saveItem = async (item: TransifexResourceObject, languages: string[], saveFn: SaveFn): Promise<void> => {
+  const slug = item.attributes.slug
+  // Exclude English (the source), locales Freshdesk can't hold, and pairs that haven't changed.
+  const saveLanguages = languages.filter(l => l !== 'en' && localeSupported(l) && pairChanged(slug, l))
   for (let i = 0; i < saveLanguages.length; i += BATCH_SIZE) {
-    await Promise.all(saveLanguages.slice(i, i + BATCH_SIZE).map(l => saveFn(item, l))).catch(err =>
-      recordFailure(`saving ${item.attributes.slug}`, err),
+    // Out of time: leave the rest of this resource's locales for a later run. They stay unmarked, so
+    // the next run still sees them as changed and picks them up.
+    if (runBudgetExhausted()) {
+      deferredForBudget += saveLanguages.length - i
+      break
+    }
+    await Promise.all(
+      saveLanguages.slice(i, i + BATCH_SIZE).map(async l => {
+        try {
+          if (await saveFn(item, l)) {
+            markSynced(slug, l)
+          }
+        } catch (err) {
+          recordFailure(`saving ${slug} for ${l}`, err)
+        }
+      }),
     )
   }
 }

--- a/scripts/lib/sync-baseline.mts
+++ b/scripts/lib/sync-baseline.mts
@@ -1,0 +1,57 @@
+/**
+ * @file
+ * Load and persist the help sync's "last synced" baseline: a map of `<resourceSlug>:<localeCode>` to
+ * the Transifex last-translation-update timestamp we most recently pushed to Freshdesk. Comparing a
+ * pair's current Transifex stat against this baseline is how the sync decides whether that pair needs
+ * re-pushing, so only changed pairs incur Freshdesk writes.
+ *
+ * The file location is overridable via `HELP_SYNC_BASELINE_FILE` so the persistence mechanism (a
+ * committed repo file vs. a restored CI cache) can change without touching this code.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
+import { messageOf } from './errors.mts'
+
+/** A map of `<resourceSlug>:<localeCode>` to the last-synced timestamp (or null if never translated). */
+export type SyncBaseline = Map<string, string | null>
+
+/** Default on-disk location of the baseline manifest, relative to the repository root. */
+export const DEFAULT_BASELINE_PATH = 'scripts/help-sync-baseline.json'
+
+const baselinePath = (path?: string): string => path ?? process.env.HELP_SYNC_BASELINE_FILE ?? DEFAULT_BASELINE_PATH
+
+/**
+ * Load the baseline from disk. A missing baseline means "sync everything" — the safe default — so an
+ * absent or unreadable file resolves to an empty map rather than an error.
+ * @param path - override for the baseline file location; defaults to `HELP_SYNC_BASELINE_FILE` or {@link DEFAULT_BASELINE_PATH}
+ * @returns the persisted baseline, or an empty map if none exists yet
+ */
+export const loadBaseline = (path?: string): SyncBaseline => {
+  const file = baselinePath(path)
+  try {
+    const parsed = JSON.parse(readFileSync(file, 'utf8')) as Record<string, string | null>
+    return new Map(Object.entries(parsed))
+  } catch (error) {
+    // A corrupt or unreadable file must not wedge the run: log (unless it is simply absent) and start
+    // fresh, which just means a one-time full sync that repopulates the baseline.
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn(`Could not read help-sync baseline "${file}"; treating as empty: ${messageOf(error)}`)
+    }
+    return new Map()
+  }
+}
+
+/**
+ * Persist the baseline to disk, sorted by key for a stable, diff-friendly file.
+ * @param baseline - the baseline to write
+ * @param path - override for the baseline file location; defaults to `HELP_SYNC_BASELINE_FILE` or {@link DEFAULT_BASELINE_PATH}
+ */
+export const saveBaseline = (baseline: SyncBaseline, path?: string): void => {
+  const file = baselinePath(path)
+  mkdirSync(dirname(file), { recursive: true })
+  const sorted: Record<string, string | null> = {}
+  for (const key of [...baseline.keys()].sort()) {
+    sorted[key] = baseline.get(key) ?? null
+  }
+  writeFileSync(file, JSON.stringify(sorted, null, 2) + '\n')
+}

--- a/scripts/lib/transifex-objects.mts
+++ b/scripts/lib/transifex-objects.mts
@@ -98,6 +98,37 @@ export interface TransifexProjectObject extends TransifexObject {
 }
 
 /**
+ * Transifex object representing per-resource, per-language translation statistics.
+ * @see https://developers.transifex.com/reference/get_resource-language-stats
+ */
+export interface TransifexResourceLanguageStatsObject extends TransifexObject {
+  /** The type of the object. */
+  type: 'resource_language_stats'
+  /** Identifier combining resource and language. Example: `o:org:p:project:r:resource:l:lang` */
+  id: `o:${string}:p:${string}:r:${string}:l:${string}`
+  attributes: {
+    /** Total number of source strings. */
+    total_strings: number
+    /** Number of translated strings. */
+    translated_strings: number
+    /** Number of untranslated strings. */
+    untranslated_strings: number
+    /** Number of reviewed strings. */
+    reviewed_strings: number
+    /** Number of strings that have cleared the second (proofread) review step. */
+    proofread_strings: number
+    /** ISO datetime of the most recent translation update, or null if never translated. */
+    last_translation_update: string | null
+    /** ISO datetime of the most recent update of any kind to this pair, or null. */
+    last_update: string | null
+    /** ISO datetime of the most recent review update, or null. */
+    last_review_update: string | null
+    /** ISO datetime of the most recent proofread update, or null. */
+    last_proofread_update: string | null
+  }
+}
+
+/**
  * Transifex object representing a Resource.
  * @see https://developers.transifex.com/reference/get_resources-resource-id
  */

--- a/scripts/lib/transifex.mts
+++ b/scripts/lib/transifex.mts
@@ -5,7 +5,11 @@
 import { transifexApi, Collection, JsonApiResource } from '@transifex/api'
 import { messageOf } from './errors.mts'
 import { TransifexStrings } from './transifex-formats.mts'
-import { TransifexLanguageObject, TransifexResourceObject } from './transifex-objects.mts'
+import {
+  TransifexLanguageObject,
+  TransifexResourceLanguageStatsObject,
+  TransifexResourceObject,
+} from './transifex-objects.mts'
 
 const ORG_NAME = 'llk'
 const SOURCE_LOCALE = 'en'
@@ -32,8 +36,81 @@ const TX_UPLOAD_POLL_INTERVAL_MS = 2_000
 const TX_UPLOAD_TIMEOUT_MS = 5 * 60_000
 /** Per-request timeout for downloading a resource from the CDN, in milliseconds. */
 const TX_DOWNLOAD_TIMEOUT_MS = 60_000
+/**
+ * Maximum number of Transifex download events to create concurrently. Each `txPull` creates a
+ * download event (a rate-limited API call); fanning every (resource, locale) pair out at once
+ * overruns the API's throttle. Bounding the create step keeps a bulk pull under the limit while
+ * still overlapping enough requests to make progress.
+ */
+const TX_MAX_CONCURRENT_DOWNLOADS = 4
+/** Upper bound on how long to honor a throttle's "expected available" hint before giving up on it. */
+const TX_MAX_THROTTLE_WAIT_MS = 120_000
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * Builds a concurrency limiter: the returned function runs at most `max` of the tasks handed to it at
+ * once and queues the rest, preserving submission order. Used to bound how many Transifex download
+ * events are created in parallel so a bulk pull stays under the API rate limit.
+ * @param max - the greatest number of tasks allowed to run at the same time
+ * @returns a function that schedules a task and resolves (or rejects) with its result
+ */
+const limitConcurrency = (max: number): (<T>(task: () => Promise<T>) => Promise<T>) => {
+  let active = 0
+  const queue: (() => void)[] = []
+  const startNext = (): void => {
+    active--
+    queue.shift()?.()
+  }
+  return <T,>(task: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const run = (): void => {
+        active++
+        // Invoke task() inside a then so a synchronous throw becomes a rejection: otherwise it would
+        // escape run(), skip finally(startNext), and leak `active` -- eventually deadlocking the queue.
+        void Promise.resolve().then(task).then(resolve, reject).finally(startNext)
+      }
+      if (active < max) {
+        run()
+      } else {
+        queue.push(run)
+      }
+    })
+}
+
+/** Bounds creation of download events so a bulk pull stays under the Transifex rate limit. */
+const downloadLimit = limitConcurrency(TX_MAX_CONCURRENT_DOWNLOADS)
+
+/**
+ * How long Transifex asked us to wait, if a 429 said. Transifex reports throttling as
+ * "Request was throttled. Expected available in N seconds." (and some errors carry a numeric
+ * `retry_after`); honoring that recovers sooner and more reliably than a blind exponential backoff.
+ * @param err - the thrown error
+ * @returns the requested wait in milliseconds (with a small cushion, capped), or null if this is not
+ * a throttle carrying a hint we can read
+ */
+const throttleWaitMs = (err: unknown): number | null => {
+  const e = (err ?? {}) as {
+    statusCode?: number
+    status?: number
+    retry_after?: number
+    errors?: { detail?: string }[]
+    message?: string
+  }
+  const status = e.statusCode ?? e.status
+  if (status !== 429) {
+    return null
+  }
+  if (typeof e.retry_after === 'number' && e.retry_after > 0) {
+    return Math.min((e.retry_after + 1) * 1_000, TX_MAX_THROTTLE_WAIT_MS)
+  }
+  const detail = e.errors?.[0]?.detail ?? e.message ?? ''
+  const match = /available in (\d+)\s*second/i.exec(detail)
+  if (match) {
+    return Math.min((parseInt(match[1], 10) + 1) * 1_000, TX_MAX_THROTTLE_WAIT_MS)
+  }
+  return null
+}
 
 /**
  * Decide whether an error is worth retrying: server-side 5xx, rate limiting (429), or a transient
@@ -88,7 +165,9 @@ const withRetry = async function <T>(label: string, fn: () => Promise<T>): Promi
       if (!isTransientError(err) || attempt === TX_MAX_TRANSIENT_RETRIES) {
         throw err
       }
-      const delay = TX_RETRY_BASE_MS * 2 ** (attempt - 1)
+      // If Transifex threw a throttle telling us when it will be available, wait exactly that long
+      // (plus a cushion); otherwise fall back to exponential backoff.
+      const delay = throttleWaitMs(err) ?? TX_RETRY_BASE_MS * 2 ** (attempt - 1)
       console.warn(
         `${label}: transient error on attempt ${attempt}/${TX_MAX_TRANSIENT_RETRIES}, ` +
           `retrying in ${delay}ms: ${messageOf(err)}`,
@@ -205,9 +284,13 @@ export const txPull = async function <T>(
   let buffer: string | null = null
   try {
     // Creating the download event itself polls Transifex until the file is ready; retry transient
-    // failures (5xx / network blips) so one bad response doesn't sink the whole pull.
-    const url = await withRetry(`txPull download event for ${resource}/${locale}`, () =>
-      getResourceLocation(project, resource, locale, mode),
+    // failures (5xx / network blips) so one bad response doesn't sink the whole pull. Gate it through
+    // the shared limiter so a bulk pull creates only a few download events at a time and stays under
+    // the API rate limit (the slot is held across retries, so throttling naturally slows the fan-out).
+    const url = await downloadLimit(() =>
+      withRetry(`txPull download event for ${resource}/${locale}`, () =>
+        getResourceLocation(project, resource, locale, mode),
+      ),
     )
     let lastError: unknown
     for (let i = 0; i < 5; i++) {
@@ -289,6 +372,45 @@ export const txResourcesObjects = async function (project: string): Promise<Tran
   })
 
   return collectAll<TransifexResourceObject>(resources)
+}
+
+/**
+ * Fetches per-(resource, locale) translation statistics for a project in a single paginated query.
+ * Used to detect which pairs changed since a previous sync without downloading any translation files:
+ * comparing the returned timestamp against a stored baseline tells us whether a pair needs re-pushing.
+ * @param project - project slug (for example, `scratch-help`)
+ * @returns a map keyed `<resourceSlug>:<localeCode>` whose value is the ISO datetime that pair's
+ * translations were last updated (falling back to the pair's last update of any kind), or null if the
+ * pair has never been translated
+ */
+export const txResourceLanguageStats = async function (project: string): Promise<Map<string, string | null>> {
+  const stats = transifexApi.ResourceLanguageStats.filter({
+    project: `o:${ORG_NAME}:p:${project}`,
+  })
+  const statsData = await collectAll<TransifexResourceLanguageStatsObject>(stats)
+
+  const lastUpdatedByPair = new Map<string, string | null>()
+  for (const stat of statsData) {
+    // id form: o:llk:p:<project>:r:<resource>:l:<locale> — resource slugs and locale codes never
+    // contain a colon, so splitting on the delimiters recovers both halves.
+    const afterResource = stat.id.split(':r:')[1]
+    if (!afterResource) {
+      continue
+    }
+    const [resource, locale] = afterResource.split(':l:')
+    if (!resource || !locale) {
+      continue
+    }
+    // A pair with no translated strings has never been translated: map it to null so the gate skips
+    // it. Falling back to last_update (which is set even for untranslated pairs) would instead make
+    // the gate treat it as changed and sync empty/untranslated content.
+    const attrs = stat.attributes
+    lastUpdatedByPair.set(
+      `${resource}:${locale}`,
+      attrs.translated_strings > 0 ? (attrs.last_translation_update ?? attrs.last_update) : null,
+    )
+  }
+  return lastUpdatedByPair
 }
 
 /**

--- a/scripts/tx-pull-help-articles.mts
+++ b/scripts/tx-pull-help-articles.mts
@@ -3,7 +3,14 @@
  * @file
  * Script to pull scratch-help translations from transifex and push to FreshDesk.
  */
-import { getInputs, saveItem, localizeFolder, reportFailures } from './lib/help-utils.mts'
+import {
+  getInputs,
+  saveItem,
+  localizeFolder,
+  initChangeDetection,
+  reportSkippedLocales,
+  finalizeSync,
+} from './lib/help-utils.mts'
 
 const args = process.argv.slice(2)
 const usage = `
@@ -21,7 +28,9 @@ if (!process.env.TX_TOKEN || !process.env.FRESHDESK_TOKEN || args.length > 0) {
   process.exit(1)
 }
 
+await initChangeDetection()
 const { languages, folders } = await getInputs()
+reportSkippedLocales(languages)
 console.log('Processing articles pulled from Transifex')
 await Promise.all(folders.map(item => saveItem(item, languages, localizeFolder)))
-reportFailures()
+finalizeSync()

--- a/scripts/tx-pull-help-names.mts
+++ b/scripts/tx-pull-help-names.mts
@@ -9,7 +9,9 @@ import {
   saveItem,
   localizeNames,
   logFreshdeskAgent,
-  reportFailures,
+  initChangeDetection,
+  reportSkippedLocales,
+  finalizeSync,
 } from './lib/help-utils.mts'
 
 const args = process.argv.slice(2)
@@ -30,11 +32,13 @@ if (!process.env.TX_TOKEN || !process.env.FRESHDESK_TOKEN || args.length > 0) {
 }
 
 await logFreshdeskAgent()
+await initChangeDetection()
 
 const [{ languages, names }, { validCategoryIds, validFolderIds }] = await Promise.all([
   getInputs(),
   getValidFreshdeskIds(),
 ])
+reportSkippedLocales(languages)
 const warnedKeys = new Set<string>()
 console.log('Process Category and Folder Names pulled from Transifex')
 await Promise.all(
@@ -44,4 +48,4 @@ await Promise.all(
     ),
   ),
 )
-reportFailures()
+finalizeSync()


### PR DESCRIPTION
### Proposed Changes

Builds on #818 (Freshdesk write pacing). Pacing keeps the writes well-behaved,
but the daily sync still attempted every translation for every locale on every
run (~10k-14k Freshdesk writes), which is too much volume to finish inside the
job timeout. This reduces the volume to only what actually changed, fixes the
translation create path, and paces the Transifex read side too.

**Change detection.** Pull per-(resource, locale) translation stats from
Transifex once per run and compare each pair's last-update timestamp against a
persisted baseline; skip any pair that hasn't changed since the last successful
sync. A normal day drops from ~10k writes to tens or hundreds. A pair's baseline
entry only advances after its write succeeds, so a failed or interrupted pair
re-syncs next run rather than being silently skipped.

**Baseline persistence + bootstrap.** The baseline lives in a GitHub Actions
cache (restored at job start, saved at the end) rather than being recomputed or
committed. Because the cache's save step is skipped when a job is cancelled, the
sync enforces its own soft wall-clock budget (`HELP_SYNC_MAX_MINUTES`, default
24, under the 30-minute hard timeout): once exceeded it stops starting new
writes, persists the baseline for everything finished, and exits cleanly so the
cache saves. A first-time full sync that can't finish in one run therefore
converges over several daily runs instead of losing all progress to a timeout.

**Create path.** Consolidate the three translation writers into one optimistic
helper: PUT to update, and only POST to create on a 404. If the create is
refused because the record already exists (409, or 405 where the endpoint allows
only GET/PUT) it's treated as a non-fatal warning rather than failing the run.
Read the helpdesk settings once and skip locales Freshdesk isn't configured to
hold translations for, reporting the skipped set in a single warning.

**Transifex read pacing.** A bulk pull creates one download event per pair;
fanning them all out at once overran Transifex's own rate limit. Bound
concurrent download-event creation and honor Transifex's "expected available in
N seconds" throttle hint, mirroring the Freshdesk write pacing.

**Dry-run mode.** A `workflow_dispatch` input runs the whole pipeline (including
change detection) and reports what would sync, without issuing any Freshdesk
writes or advancing the baseline, for validating the gate safely.
