### PR TITLE
Make the daily help sync survive its timeout

### DIFF
--- a/.github/workflows/daily-help-update.yml
+++ b/.github/workflows/daily-help-update.yml
@@ -24,11 +24,23 @@ permissions:
 jobs:
   daily-help-update:
     runs-on: ubuntu-latest
-    # Hard backstop against an unexpected hang. The sync stops issuing new writes at its own softer
-    # wall-clock budget (HELP_SYNC_MAX_MINUTES, default 24) and exits cleanly under this limit, so the
-    # cache save below always runs and partial progress from a first-time full sync is never lost to a
-    # cancellation.
-    timeout-minutes: 30
+    # Loose backstop for steps without their own timeout (setup, push) and for an unexpected hang. The
+    # per-phase sync steps below carry their own step-level timeouts, and the sync stops issuing new
+    # writes at its softer wall-clock budget (HELP_SYNC_MAX_MINUTES) before those fire, so this job cap
+    # is rarely the thing that ends a run.
+    timeout-minutes: 45
+
+    env:
+      # Non-secret config, safe to share with every step. The Freshdesk/Transifex tokens are NOT here:
+      # they are scoped to the phase steps that need them (below) so the rest of the job never sees them.
+      # Default soft wall-clock budget per sync phase, kept under the articles step's timeout-minutes so
+      # the sync stops starting writes and exits cleanly (reporting failures) before the step is
+      # hard-killed. The shorter names step overrides this under its own timeout.
+      HELP_SYNC_MAX_MINUTES: '27'
+      # Empty except on a manual dry-run dispatch, where it makes the pull report what it would write to
+      # Freshdesk without issuing any writes. Read through github.event.inputs (rather than the inputs
+      # context) so scheduled runs, which have no inputs, safely resolve to "not dry-run".
+      DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '' }}
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -42,46 +54,79 @@ jobs:
           npm ci
           npx browserslist@latest --update-db
 
+      # One warnings file shared by every phase step (each appends), read after the sync to surface
+      # warnings in the job summary and notify. Set here because runner.temp is not available in
+      # job-level env.
+      - name: Configure the warnings file
+        run: echo "WARNINGS_FILE=$RUNNER_TEMP/sync-help-warnings.txt" >> "$GITHUB_ENV"
+
       # The change-detection baseline records the last-synced Transifex timestamp per (resource, locale)
       # so each run only pushes what changed. It is not committed; it lives in the cache. The key is
-      # unique per run attempt (run_id + run_attempt, since a re-run keeps the same run_id) so the
-      # post-job save always stores that attempt's updated baseline, and restore-keys pulls the most
-      # recent prior baseline. If the cache is ever evicted, the baseline is simply rebuilt by a
-      # one-time full sync (which converges over a few runs).
-      - name: Restore and save the help-sync baseline
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # unique per run attempt (run_id + run_attempt, since a re-run keeps the same run_id) so the save
+      # step stores that attempt's updated baseline, and restore-keys pulls the most recent prior
+      # baseline. If the cache is ever evicted, the baseline is simply rebuilt by a one-time full sync
+      # (which converges over a few runs). Restore and save are split so the save can run on
+      # cancellation (see the save step below).
+      - name: Restore the help-sync baseline
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: scripts/help-sync-baseline.json
           key: help-sync-baseline-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             help-sync-baseline-
 
-      - name: Sync help
+      # The sync runs as separate phase steps, each its own process. Splitting them gives the expensive
+      # articles phase its own step-level timeout measured from its own start (rather than sharing one
+      # job-wide clock), and makes it clear in the logs which phase ran long. Push source to Transifex
+      # first, but not on a dry run, whose purpose is to report what would sync without mutating anything.
+      - name: Push help source to Transifex
+        if: ${{ github.event.inputs.dry_run != 'true' }}
         env:
-          # Organization-wide secrets
           FRESHDESK_TOKEN: ${{ secrets.FRESHDESK_TOKEN }}
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
-          WARNINGS_FILE: ${{ runner.temp }}/sync-help-warnings.txt
-          # Empty except on a manual dry-run dispatch, where it makes the pull report what it would
-          # write to Freshdesk without issuing any writes. Read through github.event.inputs (rather than
-          # the inputs context) so scheduled runs, which have no inputs, safely resolve to "not dry-run".
-          DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '' }}
-        run: |
-          if [ -n "$DRY_RUN" ]; then
-            echo "DRY RUN: pulling and reporting what would sync, without writing to Freshdesk."
-            npm run pull:help
-          else
-            npm run sync:help
-          fi
+        run: npm run push:help
+
+      - name: Sync category and folder names
+        # Small phase (two resources); both caps are generous for it and should never be reached. Its
+        # soft budget overrides the job default to stay under this timeout, so if it ever did run long it
+        # would still stop and exit cleanly before being hard-killed, matching the articles phase.
+        timeout-minutes: 10
+        env:
+          FRESHDESK_TOKEN: ${{ secrets.FRESHDESK_TOKEN }}
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+          HELP_SYNC_MAX_MINUTES: '8'
+        run: npm run pull:help:names
+
+      - name: Sync articles
+        # The large phase. Its timeout sits just above HELP_SYNC_MAX_MINUTES so the soft budget stops
+        # new writes and the run exits cleanly before this hard cap fires.
+        timeout-minutes: 30
+        env:
+          FRESHDESK_TOKEN: ${{ secrets.FRESHDESK_TOKEN }}
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+        run: npm run pull:help:articles
+
+      # Save the baseline even when the sync is cancelled -- most importantly when a phase step hits its
+      # timeout mid-sync during a first-time full sync (or the job hits its cap). The sync flushes
+      # progress to disk as it goes, so this caches whatever finished and the next run continues from it.
+      # always() is required: the default (success()) and !cancelled() both skip on cancellation, which
+      # is exactly when saving partial progress matters most. Skipped on dry runs, which never write the
+      # baseline (nothing new to cache; avoids a spurious "path does not exist" warning).
+      - name: Save the help-sync baseline
+        if: ${{ always() && github.event.inputs.dry_run != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: scripts/help-sync-baseline.json
+          key: help-sync-baseline-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Check for warnings
         id: check-warnings
         if: success()
         run: |
-          if [ -s "${{ runner.temp }}/sync-help-warnings.txt" ]; then
+          if [ -s "$WARNINGS_FILE" ]; then
             echo "has_warnings=true" >> "$GITHUB_OUTPUT"
             echo "### Sync Help Warnings" >> "$GITHUB_STEP_SUMMARY"
-            cat "${{ runner.temp }}/sync-help-warnings.txt" >> "$GITHUB_STEP_SUMMARY"
+            cat "$WARNINGS_FILE" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - uses: ./.github/actions/report-scheduled-issue

--- a/scripts/lib/help-utils.mts
+++ b/scripts/lib/help-utils.mts
@@ -61,16 +61,22 @@ const DRY_RUN = !!process.env.DRY_RUN && process.env.DRY_RUN !== '0' && process.
 /**
  * Wall-clock budget for a single run, in minutes (override with `HELP_SYNC_MAX_MINUTES`). When it is
  * exceeded the sync stops starting new writes, persists the baseline for everything that finished, and
- * exits cleanly. This matters because the baseline is restored from and saved to a CI cache whose save
- * step only runs when the job is not cancelled: finishing under the job's hard `timeout-minutes` keeps
- * partial progress, so a first-time full sync that cannot complete in one run converges over several
- * daily runs instead of losing everything to a timeout.
+ * exits cleanly. Durability across a cancellation is already handled by the incremental baseline flush
+ * plus the workflow's save-on-cancel step, so this budget is the graceful path, not the safety net:
+ * exiting cleanly under the step's hard `timeout-minutes` lets the run print its failure summary, exit
+ * non-zero on genuine errors, and finish as a success rather than a cancellation -- so real problems
+ * surface (and alert) while the baseline is still converging instead of being masked by a timeout.
  */
 const RUN_TIME_BUDGET_MS = (() => {
   const minutes = Number(process.env.HELP_SYNC_MAX_MINUTES)
   return (Number.isFinite(minutes) && minutes > 0 ? minutes : 24) * 60_000
 })()
-/** When this run began, used to enforce {@link RUN_TIME_BUDGET_MS}. */
+/**
+ * When this run began, used to enforce {@link RUN_TIME_BUDGET_MS}. Each sync phase (`pull:help:names`,
+ * `pull:help:articles`) runs as its own job step with its own step-level `timeout-minutes`, so this
+ * per-process clock starts alongside that step's timeout: the soft budget sits just under it, stopping
+ * new writes and exiting cleanly (reporting failures) before the step is hard-killed.
+ */
 const runStartedAt = Date.now()
 /** Count of changed, supported pairs left unattempted because the run hit its time budget. */
 let deferredForBudget = 0
@@ -192,6 +198,49 @@ const markSynced = (resource: string, locale: string): void => {
   }
 }
 
+/** Minimum interval between incremental baseline flushes, to bound both progress loss and write churn. */
+const BASELINE_FLUSH_INTERVAL_MS = 15_000
+/** When the baseline was last flushed to disk, used to debounce {@link maybeFlushBaseline}. */
+let lastBaselineFlushAt = 0
+
+/**
+ * Merge the pairs synced so far into the baseline and persist it to disk. A no-op in a dry run (which
+ * must never mutate the baseline) and before change detection is initialized: a script that calls
+ * saveItem without initChangeDetection (the locale-debug pull) leaves baseline/currentStats empty, and
+ * persisting then would clobber the real baseline with an empty file, forcing the next sync to re-sync
+ * everything. Safe to call from concurrently-running saveItem tasks: JS is single-threaded and
+ * {@link saveBaseline} writes atomically, so calls cannot interleave a partial file.
+ */
+const flushBaseline = (): void => {
+  if (DRY_RUN || !changeDetectionReady) {
+    return
+  }
+  for (const [key, timestamp] of syncedPairs) {
+    baseline.set(key, timestamp)
+  }
+  saveBaseline(baseline)
+  lastBaselineFlushAt = Date.now()
+}
+
+/**
+ * Persist the baseline if enough time has passed since the last flush. Called as the sync makes
+ * progress so a run cancelled mid-sync (for example by its phase step's timeout) still keeps what it
+ * finished on disk, letting the workflow's save-on-cancel step cache it and the next run continue
+ * instead of restarting a full sync. The graceful path still calls {@link flushBaseline} once more at
+ * the end via {@link finalizeSync}.
+ */
+const maybeFlushBaseline = (): void => {
+  // Nothing to persist in a dry run or before change detection is initialized, so skip the debounce
+  // entirely rather than calling flushBaseline (a no-op there) on every batch. flushBaseline keeps the
+  // same guards for the finalizeSync path.
+  if (DRY_RUN || !changeDetectionReady) {
+    return
+  }
+  if (Date.now() - lastBaselineFlushAt >= BASELINE_FLUSH_INTERVAL_MS) {
+    flushBaseline()
+  }
+}
+
 /**
  * Finish the run: persist the advanced baseline (unless this is a dry run) and print the failure
  * summary. Call once, after all saves have completed.
@@ -203,10 +252,7 @@ export const finalizeSync = (): void => {
         `${plannedWrites} Freshdesk write(s). No writes were issued and the baseline was left unchanged.`,
     )
   } else {
-    for (const [key, timestamp] of syncedPairs) {
-      baseline.set(key, timestamp)
-    }
-    saveBaseline(baseline)
+    flushBaseline()
     console.log(`Synced ${syncedPairs.size} (resource, locale) pair(s); baseline now holds ${baseline.size} entries.`)
   }
   if (deferredForBudget > 0) {
@@ -537,5 +583,8 @@ export const saveItem = async (item: TransifexResourceObject, languages: string[
         }
       }),
     )
+    // Persist progress periodically so a run cancelled mid-sync keeps what it finished (see
+    // maybeFlushBaseline); the interval debounce keeps this from writing on every batch.
+    maybeFlushBaseline()
   }
 }

--- a/scripts/lib/sync-baseline.mts
+++ b/scripts/lib/sync-baseline.mts
@@ -8,7 +8,7 @@
  * The file location is overridable via `HELP_SYNC_BASELINE_FILE` so the persistence mechanism (a
  * committed repo file vs. a restored CI cache) can change without touching this code.
  */
-import { readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { readFileSync, writeFileSync, mkdirSync, renameSync } from 'fs'
 import { dirname } from 'path'
 import { messageOf } from './errors.mts'
 
@@ -42,7 +42,11 @@ export const loadBaseline = (path?: string): SyncBaseline => {
 }
 
 /**
- * Persist the baseline to disk, sorted by key for a stable, diff-friendly file.
+ * Persist the baseline to disk, sorted by key for a stable, diff-friendly file. The write is atomic
+ * (write a temp file, then rename over the target) because the sync flushes the baseline repeatedly
+ * as it makes progress and relies on the file surviving an abrupt kill (a job timeout mid-write). A
+ * partial `writeFileSync` would otherwise leave a truncated file that {@link loadBaseline} discards as
+ * corrupt, throwing away every pair synced so far. `renameSync` within the same directory is atomic.
  * @param baseline - the baseline to write
  * @param path - override for the baseline file location; defaults to `HELP_SYNC_BASELINE_FILE` or {@link DEFAULT_BASELINE_PATH}
  */
@@ -53,5 +57,7 @@ export const saveBaseline = (baseline: SyncBaseline, path?: string): void => {
   for (const key of [...baseline.keys()].sort()) {
     sorted[key] = baseline.get(key) ?? null
   }
-  writeFileSync(file, JSON.stringify(sorted, null, 2) + '\n')
+  const tempFile = `${file}.tmp`
+  writeFileSync(tempFile, JSON.stringify(sorted, null, 2) + '\n')
+  renameSync(tempFile, file)
 }


### PR DESCRIPTION
### Resolves

Follow-up to scratchfoundation/scratch-l10n#820; no separate issue.

The first live run after #820 (Daily Help Update run 30588725987) was cancelled at the job's hard timeout mid-sync, so the baseline was never persisted and the first-time full sync made no durable progress.

### Proposed Changes

The soft time budget was meant to stop the sync before the 30-minute hard timeout and let the cache save, but it never fired. `sync:help` runs as three separate processes (`push:help`, `pull:help:names`, `pull:help:articles`), each with its own module-load clock, so the articles phase's 24-minute budget restarted about ten minutes into the job and expired after the hard timeout. The job was cancelled mid-pull, and a cancelled job skips the cache save, so nothing persisted.

This makes the sync survive its timeout, two ways:

**Per-phase steps with their own timeouts.** Each sync phase now runs as its own job step: push (skipped on a dry run), names (`timeout-minutes: 10`), and articles (`timeout-minutes: 30`). The expensive articles phase gets its own step timeout measured from its own start, so the per-process soft budget (`HELP_SYNC_MAX_MINUTES`, kept under the articles step timeout) lines up with the deadline it is meant to beat instead of restarting partway through the job. The job timeout becomes a loose 45-minute backstop for the untimed steps, and the logs now make clear which phase ran long. The soft budget is now purely the graceful path: a clean success, the failure summary, and a non-zero exit that alerts on genuine errors while the baseline is still converging.

**Durable progress, so the timeout value is no longer load-bearing.** The baseline is flushed to disk as pairs complete (debounced to at most every 15s), `saveBaseline` writes atomically (temp file then rename) so a write interrupted by a kill cannot truncate the file into something the loader discards as corrupt, and the combined cache is split into a restore plus a save that runs with `if: always()`, so partial progress is cached even when a phase step or the job is cancelled.

Steady state is unaffected: a normal day writes tens to hundreds of pairs and finishes in a couple of minutes, never approaching any of these limits.

Validated with typecheck, eslint, and actionlint; the atomic baseline save round-trips in a standalone test. A dry-run dispatch on this branch exercises the step and budget structure; the durability path (incremental flush and save-on-cancel) is exercised by the next live or scheduled run.
